### PR TITLE
TR2 FD updates

### DIFF
--- a/src/Actions/TRFloorDataEdit.cs
+++ b/src/Actions/TRFloorDataEdit.cs
@@ -9,7 +9,6 @@ public class TRFloorDataEdit
     public short RoomIndex { get; set; }
     public ushort X { get; set; }
     public ushort Z { get; set; }
-    public uint NewFDLength => (uint)Fixes.Sum(f => f.NewFDLength);
     public List<FDFix> Fixes { get; set; }
 
     public void Serialize(TRLevelWriter writer)
@@ -34,7 +33,6 @@ public enum FDFixType
 public abstract class FDFix
 {
     public abstract FDFixType FixType { get; }
-    public abstract uint NewFDLength { get; }
 
     public void Serialize(TRLevelWriter writer)
     {
@@ -48,7 +46,6 @@ public abstract class FDFix
 public class FDTrigItem : FDFix
 {
     public override FDFixType FixType => FDFixType.TrigItem;
-    public override uint NewFDLength => 0;
     public TR1Entity Item { get; set; }
 
     protected override void SerializeImpl(TRLevelWriter writer)
@@ -60,7 +57,6 @@ public class FDTrigItem : FDFix
 public class FDTrigParamFix : FDFix
 {
     public override FDFixType FixType => FDFixType.TrigParam;
-    public override uint NewFDLength => 0;
     public FDTrigAction ActionType { get; set; }
     public short OldParam { get; set; }
     public short NewParam { get; set; }
@@ -76,7 +72,6 @@ public class FDTrigParamFix : FDFix
 public class FDTrigCreateFix : FDFix
 {
     public override FDFixType FixType => FDFixType.TrigCreate;
-    public override uint NewFDLength => (uint)Flatten().Count;
     public List<FDEntry> Entries { get; set; }
 
     private List<ushort> Flatten()
@@ -96,7 +91,6 @@ public class FDTrigCreateFix : FDFix
 public class FDMusicOneShot : FDFix
 {
     public override FDFixType FixType => FDFixType.MusicOneShot;
-    public override uint NewFDLength => 0;
 
     protected override void SerializeImpl(TRLevelWriter writer) { }
 }
@@ -104,7 +98,6 @@ public class FDMusicOneShot : FDFix
 public class FDRoomShift : FDFix
 {
     public override FDFixType FixType => FDFixType.RoomShift;
-    public override uint NewFDLength => 0;
     public uint XShift { get; set; }
     public uint ZShift { get; set; }
     public int YShift { get; set; }

--- a/src/Actions/TRFloorDataEdit.cs
+++ b/src/Actions/TRFloorDataEdit.cs
@@ -11,13 +11,13 @@ public class TRFloorDataEdit
     public ushort Z { get; set; }
     public List<FDFix> Fixes { get; set; }
 
-    public void Serialize(TRLevelWriter writer)
+    public void Serialize(TRLevelWriter writer, TRGameVersion version)
     {
         writer.Write(RoomIndex);
         writer.Write(X);
         writer.Write(Z);
         writer.Write((uint)Fixes.Count);
-        Fixes.ForEach(f => f.Serialize(writer));
+        Fixes.ForEach(f => f.Serialize(writer, version));
     }
 }
 
@@ -34,13 +34,13 @@ public abstract class FDFix
 {
     public abstract FDFixType FixType { get; }
 
-    public void Serialize(TRLevelWriter writer)
+    public void Serialize(TRLevelWriter writer, TRGameVersion version)
     {
         writer.Write((uint)FixType);
-        SerializeImpl(writer);
+        SerializeImpl(writer, version);
     }
 
-    protected abstract void SerializeImpl(TRLevelWriter writer);
+    protected abstract void SerializeImpl(TRLevelWriter writer, TRGameVersion version);
 }
 
 public class FDTrigItem : FDFix
@@ -48,7 +48,7 @@ public class FDTrigItem : FDFix
     public override FDFixType FixType => FDFixType.TrigItem;
     public TR1Entity Item { get; set; }
 
-    protected override void SerializeImpl(TRLevelWriter writer)
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
     {
         writer.Write(Item);
     }
@@ -61,7 +61,7 @@ public class FDTrigParamFix : FDFix
     public short OldParam { get; set; }
     public short NewParam { get; set; }
 
-    protected override void SerializeImpl(TRLevelWriter writer)
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
     {
         writer.Write((byte)ActionType);
         writer.Write(OldParam);
@@ -74,15 +74,15 @@ public class FDTrigCreateFix : FDFix
     public override FDFixType FixType => FDFixType.TrigCreate;
     public List<FDEntry> Entries { get; set; }
 
-    private List<ushort> Flatten()
+    private List<ushort> Flatten(TRGameVersion version)
     {
-        TRFDBuilder builder = new(TRGameVersion.TR1);
+        TRFDBuilder builder = new(version);
         return builder.Flatten(Entries);
     }
 
-    protected override void SerializeImpl(TRLevelWriter writer)
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
     {
-        List<ushort> data = Flatten();
+        List<ushort> data = Flatten(version);
         writer.Write((uint)data.Count);
         writer.Write(data);
     }
@@ -92,7 +92,7 @@ public class FDMusicOneShot : FDFix
 {
     public override FDFixType FixType => FDFixType.MusicOneShot;
 
-    protected override void SerializeImpl(TRLevelWriter writer) { }
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version) { }
 }
 
 public class FDRoomShift : FDFix
@@ -102,7 +102,7 @@ public class FDRoomShift : FDFix
     public uint ZShift { get; set; }
     public int YShift { get; set; }
 
-    protected override void SerializeImpl(TRLevelWriter writer)
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
     {
         writer.Write(XShift);
         writer.Write(ZShift);

--- a/src/Control/InjectionIO.cs
+++ b/src/Control/InjectionIO.cs
@@ -124,7 +124,7 @@ public static class InjectionIO
             data.SFX.ForEach(s => s.Serialize(writer));
             data.MeshEdits.ForEach(m => m.Serialize(writer));
             data.TextureOverwrites.ForEach(t => t.Serialize(writer));
-            data.FloorEdits.ForEach(f => f.Serialize(writer));
+            data.FloorEdits.ForEach(f => f.Serialize(writer, data.GameVersion));
             data.RoomEdits.ForEach(r => r.Serialize(writer));
             data.VisPortalEdits.ForEach(v => v.Serialize(writer));
             data.AnimRangeEdits.ForEach(a => a.Serialize(writer));
@@ -142,7 +142,7 @@ public static class InjectionIO
 
         {
             // Injection edits
-            data.FloorEdits.ForEach(f => f.Serialize(writer));
+            data.FloorEdits.ForEach(f => f.Serialize(writer, data.GameVersion));
         }
     }
 

--- a/src/Types/FDBuilder.cs
+++ b/src/Types/FDBuilder.cs
@@ -88,12 +88,12 @@ public abstract class FDBuilder : InjectionBuilder
 
     protected static FDTrigCreateFix MakeTrigFix(TR1Level level, short room, ushort x, ushort z)
     {
-        return MakeTrigFix(level.Rooms[room].GetSector(x, z), level.FloorData);
+        return MakeTrigFix(level.Rooms[room].GetSector(x, z, TRUnit.Sector), level.FloorData);
     }
 
     protected static FDTrigCreateFix MakeTrigFix(TR2Level level, short room, ushort x, ushort z)
     {
-        return MakeTrigFix(level.Rooms[room].GetSector(x, z), level.FloorData);
+        return MakeTrigFix(level.Rooms[room].GetSector(x, z, TRUnit.Sector), level.FloorData);
     }
 
     protected static FDTrigCreateFix MakeTrigFix(TRRoomSector sector, FDControl floorData)

--- a/src/Types/TR2/FD/TR2CatacombsFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2CatacombsFDBuilder.cs
@@ -1,0 +1,60 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.FD;
+
+public class TR2CatacombsFDBuilder : FDBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level catacombs = _control2.Read($"Resources/{TR2LevelNames.COT}");
+
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.FDFix, "catacombs_fd");
+        data.FloorEdits.AddRange(FixMaskRoomFlipmap(catacombs));
+
+        return new() { data };
+    }
+
+    private static List<TRFloorDataEdit> FixMaskRoomFlipmap(TR2Level catacombs)
+    {
+        List<TRFloorDataEdit> edits = new();
+
+        // The collapsible tile triggers and the ladder entry are missing in flipped room 116.
+        TR2Room room = catacombs.Rooms[98];
+        for (ushort x = 12; x < 15; x++)
+        {
+            TRRoomSector sector = room.GetSector(x, 8, TRUnit.Sector);
+            edits.Add(new()
+            {
+                RoomIndex = 116,
+                X = x,
+                Z = 8,
+                Fixes = new()
+                {
+                    new FDTrigCreateFix()
+                    {
+                        Entries = new(catacombs.FloorData[sector.FDIndex].Select(e => e.Clone())),
+                    }
+                }
+            });
+        }
+
+        // Similarly, the snow leopard triggers are missing.
+        FDTriggerEntry catTrigger = GetTrigger(catacombs, 98, 10, 1);
+        for (ushort z = 1; z < 9; z++)
+        {
+            edits.Add(MakeTrigger(catacombs, 116, 10, z, catTrigger.Clone() as FDTriggerEntry));
+        }
+
+        // And the goon triggers.
+        FDTriggerEntry goonTrigger = GetTrigger(catacombs, 98, 1, 5);
+        for (ushort z = 5; z < 8; z++)
+        {
+            edits.Add(MakeTrigger(catacombs, 116, 1, z, goonTrigger.Clone() as FDTriggerEntry));
+        }
+
+        return edits;
+    }
+}


### PR DESCRIPTION
- Removed legacy extra FD injection length property as it's no longer required or referenced anywhere.
- We now pass the game version to the FD serializers to ensure the underlying library accepts such things as ladder entries based on the game.
- Created a Catacombs FD injection builder to fix triggers and the ladder in room 116.