### PR TITLE
Further TR2 injection support

### DIFF
--- a/src/Actions/TRFloorDataEdit.cs
+++ b/src/Actions/TRFloorDataEdit.cs
@@ -28,6 +28,7 @@ public enum FDFixType
     TrigCreate,
     RoomShift,
     TrigItem,
+    RoomProperties,
 }
 
 public abstract class FDFix
@@ -107,5 +108,16 @@ public class FDRoomShift : FDFix
         writer.Write(XShift);
         writer.Write(ZShift);
         writer.Write(YShift);
+    }
+}
+
+public class FDRoomProperties : FDFix
+{
+    public override FDFixType FixType => FDFixType.RoomProperties;
+    public TRRoomFlag Flags { get; set; }
+
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
+    {
+        writer.Write((ushort)Flags);
     }
 }

--- a/src/Control/InjectionIO.cs
+++ b/src/Control/InjectionIO.cs
@@ -25,6 +25,7 @@ public static class InjectionIO
     private enum BlockType
     {
         FloorEdits = 0,
+        ItemEdits = 1,
     };
 
     public static void Export(InjectionData data, string file)
@@ -147,6 +148,8 @@ public static class InjectionIO
             // Injection edits
             totalBlocks += WriteBlock(BlockType.FloorEdits, data.FloorEdits.Count, blockWriter,
                 s => data.FloorEdits.ForEach(f => f.Serialize(s, data.GameVersion)));
+            totalBlocks += WriteBlock(BlockType.ItemEdits, data.ItemEdits.Count, blockWriter,
+                s => data.ItemEdits.ForEach(i => i.Serialize(s)));
         }
 
         WriteVersionAndType(data, writer);

--- a/src/Types/ItemBuilder.cs
+++ b/src/Types/ItemBuilder.cs
@@ -16,4 +16,22 @@ public abstract class ItemBuilder : InjectionBuilder
             Item = item,
         };
     }
+
+    public static TRItemEdit SetAngle(TR2Level level, short itemIndex, short angle)
+    {
+        // Convert to a TR1Entity
+        TR2Entity item = level.Entities[itemIndex];
+        return new()
+        {
+            Index = itemIndex,
+            Item = new()
+            {
+                Angle = angle,
+                X = item.X,
+                Y = item.Y,
+                Z = item.Z,
+                Room = item.Room,
+            },
+        };
+    }
 }

--- a/src/Types/TR2/FD/TR2FloatingFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2FloatingFDBuilder.cs
@@ -1,0 +1,21 @@
+﻿using TRLevelControl;
+using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.FD;
+
+public class TR2FloatingFDBuilder : FDBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level floating = _control2.Read($"Resources/{TR2LevelNames.FLOATER}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.FDFix, "floating_fd");
+
+        // Rotate and shift the door that leads to room 86, otherwise there is an invisible wall.
+        floating.Entities[72].X += TRConsts.Step4;
+        data.ItemEdits.Add(ItemBuilder.SetAngle(floating, 72, 16384));
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/FD/TR2IcePalaceFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2IcePalaceFDBuilder.cs
@@ -1,0 +1,22 @@
+﻿using TRLevelControl;
+using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.FD;
+
+public class TR2IcePalaceFDBuilder : FDBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level palace = _control2.Read($"Resources/{TR2LevelNames.CHICKEN}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.FDFix, "palace_fd");
+
+        // Rotate and shift the door that leads to the Jade secret, otherwise there is an invisible wall.
+        // Although this is an item shift, it's included in FD as it's closest to that in terms of config setting.
+        palace.Entities[143].X += TRConsts.Step4;
+        data.ItemEdits.Add(ItemBuilder.SetAngle(palace, 143, 16384));
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/FD/TR2IcePalaceFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2IcePalaceFDBuilder.cs
@@ -17,6 +17,10 @@ public class TR2IcePalaceFDBuilder : FDBuilder
         palace.Entities[143].X += TRConsts.Step4;
         data.ItemEdits.Add(ItemBuilder.SetAngle(palace, 143, 16384));
 
+        // Duplicate the gong hammer pickup trigger into the adjacent tile.
+        FDTriggerEntry hammerTrigger = GetTrigger(palace, 29, 4, 6);
+        data.FloorEdits.Add(MakeTrigger(palace, 29, 3, 6, hammerTrigger));
+
         return new() { data };
     }
 }

--- a/src/Types/TR2/FD/TR2WreckFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2WreckFDBuilder.cs
@@ -1,0 +1,30 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.FD;
+
+public class TR2WreckFDBuilder : FDBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level wreck = _control2.Read($"Resources/{TR2LevelNames.DORIA}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.FDFix, "wreck_fd");
+
+        // Flood room 98 where the unreachable shark is.
+        data.FloorEdits.Add(new()
+        {
+            RoomIndex = 98,
+            Fixes = new()
+            {
+                new FDRoomProperties
+                {
+                    Flags = wreck.Rooms[98].Flags | TRRoomFlag.Water,
+                }
+            }
+        });
+
+        return new() { data };
+    }
+}


### PR DESCRIPTION
- Adds support for editing room properties (currently flags only)
- Writes item re-positioning edits to the TR2 output file
- Adds various fixes for TR2 levels - see https://github.com/LostArtefacts/TRX/pull/1970