### PR TITLE
Create TR2 pickup rotation builders

### DIFF
--- a/src/Types/TR2/Items/TR2BarkhangItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2BarkhangItemBuilder.cs
@@ -1,0 +1,24 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2BarkhangItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level barkhang = _control2.Read($"Resources/{TR2LevelNames.MONASTERY}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "barkhang_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(barkhang, 31, -16384),
+            SetAngle(barkhang, 97, 16384),
+            SetAngle(barkhang, 176, 16384),
+            SetAngle(barkhang, 202, 16384),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2CatacombsItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2CatacombsItemBuilder.cs
@@ -1,0 +1,23 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2CatacombsItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level catacombs = _control2.Read($"Resources/{TR2LevelNames.COT}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "catacombs_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(catacombs, 9, 16384),
+            SetAngle(catacombs, 47, -32768),
+            SetAngle(catacombs, 112, -32768),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2DeckItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2DeckItemBuilder.cs
@@ -1,0 +1,21 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2DeckItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level deck = _control2.Read($"Resources/{TR2LevelNames.DECK}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "deck_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(deck, 82, -16384),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2DivingItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2DivingItemBuilder.cs
@@ -1,0 +1,24 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2DivingItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level diving = _control2.Read($"Resources/{TR2LevelNames.DA}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "diving_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(diving, 58, -32768),
+            SetAngle(diving, 94, -32768),
+            SetAngle(diving, 120, 16384),
+            SetAngle(diving, 124, -16384),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2FloatingItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2FloatingItemBuilder.cs
@@ -1,0 +1,21 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2FloatingItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level floating = _control2.Read($"Resources/{TR2LevelNames.FLOATER}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "floating_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(floating, 3, -32768),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2HSHItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2HSHItemBuilder.cs
@@ -1,0 +1,23 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2HSHItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level house = _control2.Read($"Resources/{TR2LevelNames.HOME}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "house_itemrots");
+
+        // Everything in the closet.
+        foreach (TR2Entity item in house.Entities.Where(e => e.Room == 57))
+        {
+            short angle = (short)(item.TypeID == TR2Type.Shotgun_S_P ? -32768 : 16384);
+            data.ItemEdits.Add(SetAngle(house, (short)house.Entities.IndexOf(item), angle));
+        }
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2IcePalaceItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2IcePalaceItemBuilder.cs
@@ -1,0 +1,23 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2IcePalaceItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level palace = _control2.Read($"Resources/{TR2LevelNames.CHICKEN}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "palace_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(palace, 90, -32768),
+            SetAngle(palace, 93, -32768),
+            SetAngle(palace, 151, -16384),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2OperaItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2OperaItemBuilder.cs
@@ -1,0 +1,22 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2OperaItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level opera = _control2.Read($"Resources/{TR2LevelNames.OPERA}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "opera_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(opera, 118, 16384),
+            SetAngle(opera, 82, 16384),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2RigItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2RigItemBuilder.cs
@@ -1,0 +1,21 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2RigItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level rig = _control2.Read($"Resources/{TR2LevelNames.RIG}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "rig_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(rig, 30, 16384),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2TibetItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2TibetItemBuilder.cs
@@ -1,0 +1,23 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2TibetItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level tibet = _control2.Read($"Resources/{TR2LevelNames.TIBET}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "tibet_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(tibet, 0, -32768),
+            SetAngle(tibet, 48, 16384),
+            SetAngle(tibet, 68, 16384),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2WallItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2WallItemBuilder.cs
@@ -1,0 +1,22 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2WallItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level wall = _control2.Read($"Resources/{TR2LevelNames.GW}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "wall_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(wall, 17, 16384),
+            SetAngle(wall, 92, -32768),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2WreckItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2WreckItemBuilder.cs
@@ -1,0 +1,23 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2WreckItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level wreck = _control2.Read($"Resources/{TR2LevelNames.DORIA}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "wreck_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(wreck, 64, -32768),
+            SetAngle(wreck, 149, 16384),
+            SetAngle(wreck, 183, 16384),
+        };
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Items/TR2XianItemBuilder.cs
+++ b/src/Types/TR2/Items/TR2XianItemBuilder.cs
@@ -1,0 +1,27 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Items;
+
+public class TR2XianItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level xian = _control2.Read($"Resources/{TR2LevelNames.XIAN}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.ItemRotation, "xian_itemrots");
+
+        data.ItemEdits = new()
+        {
+            SetAngle(xian, 0, 16384),
+            SetAngle(xian, 88, 16384),
+            SetAngle(xian, 95, -32768),
+            SetAngle(xian, 103, -16384),
+            SetAngle(xian, 137, -32768),
+            SetAngle(xian, 160, 16384),
+            SetAngle(xian, 217, 16384),
+        };
+
+        return new() { data };
+    }
+}


### PR DESCRIPTION
Adds pickup rotations to all TR2 levels where necessary. See https://github.com/LostArtefacts/TRX/issues/1613.