### PR TITLE
Catacombs music pads

### DIFF
--- a/src/Actions/TRFloorDataEdit.cs
+++ b/src/Actions/TRFloorDataEdit.cs
@@ -29,6 +29,7 @@ public enum FDFixType
     RoomShift,
     TrigItem,
     RoomProperties,
+    TrigType,
 }
 
 public abstract class FDFix
@@ -52,6 +53,17 @@ public class FDTrigItem : FDFix
     protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
     {
         writer.Write(Item);
+    }
+}
+
+public class FDTrigTypeFix : FDFix
+{
+    public override FDFixType FixType => FDFixType.TrigType;
+    public FDTrigType NewType { get; set; }
+
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
+    {
+        writer.Write((byte)NewType);
     }
 }
 

--- a/src/Types/FDBuilder.cs
+++ b/src/Types/FDBuilder.cs
@@ -111,4 +111,33 @@ public abstract class FDBuilder : InjectionBuilder
 
         return fd;
     }
+
+    protected static TRFloorDataEdit ConvertTrigger(TR1Level level, short room, ushort x, ushort z, FDTrigType newType)
+    {
+        return ConvertTrigger(GetTrigger(level, room, x, z), room, x, z, newType);
+    }
+
+    protected static TRFloorDataEdit ConvertTrigger(TR2Level level, short room, ushort x, ushort z, FDTrigType newType)
+    {
+        return ConvertTrigger(GetTrigger(level, room, x, z), room, x, z, newType);
+    }
+
+    protected static TRFloorDataEdit ConvertTrigger(FDTriggerEntry existingTrigger, short room, ushort x, ushort z, FDTrigType newType)
+    {
+        if (existingTrigger == null)
+        {
+            throw new Exception("A base trigger must exist for a type conversion.");
+        }
+
+        return new()
+        {
+            RoomIndex = room,
+            X = x,
+            Z = z,
+            Fixes = new()
+            {
+                new FDTrigTypeFix() { NewType = newType }
+            }
+        };
+    }
 }

--- a/src/Types/TR2/FD/TR2CatacombsFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2CatacombsFDBuilder.cs
@@ -13,6 +13,7 @@ public class TR2CatacombsFDBuilder : FDBuilder
 
         InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.FDFix, "catacombs_fd");
         data.FloorEdits.AddRange(FixMaskRoomFlipmap(catacombs));
+        data.FloorEdits.AddRange(FixStartMusicTriggers(catacombs));
 
         return new() { data };
     }
@@ -56,5 +57,20 @@ public class TR2CatacombsFDBuilder : FDBuilder
         }
 
         return edits;
+    }
+
+    private static List<TRFloorDataEdit> FixStartMusicTriggers(TR2Level catacombs)
+    {
+        // Avoid triggering dramatic music when shimmying to the stone secret, or using
+        // the ladder to reach the bottom.
+        return new()
+        {
+            ConvertTrigger(catacombs, 6, 2, 1, FDTrigType.Pad),
+            ConvertTrigger(catacombs, 6, 2, 2, FDTrigType.Pad),
+            ConvertTrigger(catacombs, 6, 3, 3, FDTrigType.Pad),
+            ConvertTrigger(catacombs, 6, 3, 4, FDTrigType.Pad),
+            ConvertTrigger(catacombs, 74, 2, 1, FDTrigType.Pad),
+            ConvertTrigger(catacombs, 74, 2, 2, FDTrigType.Pad),
+        };
     }
 }


### PR DESCRIPTION
This allows simple trigger type edits, and adds conversions to pads for the music triggers at the start of Catacombs in TR2. See https://github.com/LostArtefacts/TRX/issues/1962.