### PR TITLE
Fix various TR1 texture transparency issues

### DIFF
--- a/src/Types/TR1/Textures/TR1CatTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1CatTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using System.Drawing;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -15,6 +16,8 @@ public class TR1CatTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateFillers(cat));
         data.RoomEdits.AddRange(CreateRefacings());
         data.RoomEdits.AddRange(CreateRotations());
+
+        FixTransparentTextures(cat, data);
 
         return new() { data };
     }
@@ -85,5 +88,13 @@ public class TR1CatTextureBuilder : TextureBuilder
             Rotate(96, TRMeshFaceType.TexturedQuad, 73, 3),
             Rotate(96, TRMeshFaceType.TexturedQuad, 27, 1),
         };
+    }
+
+    private static void FixTransparentTextures(TR1Level cat, InjectionData data)
+    {
+        TR1CommonTextureBuilder.FixTransparentPixels(cat, data,
+            cat.Rooms[2].Mesh.Rectangles[128], Color.FromArgb(188, 140, 64));
+        TR1CommonTextureBuilder.FixTransparentPixels(cat, data,
+            cat.Rooms[7].Mesh.Rectangles[19], Color.FromArgb(188, 140, 64));
     }
 }

--- a/src/Types/TR1/Textures/TR1CavesTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1CavesTextureBuilder.cs
@@ -16,6 +16,9 @@ public class TR1CavesTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(caves));
         data.RoomEdits.AddRange(CreateShifts(caves));
 
+        TR1CommonTextureBuilder.FixBatTransparency(caves, data);
+        TR1CommonTextureBuilder.FixWolfTransparency(caves, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR1/Textures/TR1CommonTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1CommonTextureBuilder.cs
@@ -1,0 +1,86 @@
+﻿using System.Diagnostics;
+using System.Drawing;
+using TRImageControl;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR1.Textures;
+
+public static class TR1CommonTextureBuilder
+{
+    public static void FixWolfTransparency(TR1Level level, InjectionData data)
+    {
+        List<ushort> eyeVerts = new() { 20, 13, 12, 22 };
+        TRMeshFace eyeFace = level.Models[TR1Type.Wolf]
+            .Meshes[3]
+            .TexturedRectangles.Find(t => t.Vertices.All(eyeVerts.Contains));
+
+        FixTransparentPixels(level, data, eyeFace, Color.FromArgb(228, 228, 228));
+    }
+
+    public static void FixBatTransparency(TR1Level level, InjectionData data)
+    {
+        List<ushort> eyeVerts = new() { 0, 1, 3 };
+        TRMeshFace eyeFace = level.Models[TR1Type.Bat]
+            .Meshes[4]
+            .TexturedTriangles.Find(t => t.Vertices.All(eyeVerts.Contains));
+
+        FixTransparentPixels(level, data, eyeFace, Color.Black);
+    }
+
+    public static void FixTransparentPixels(TR1Level level, InjectionData data, TRFace face, Color fillColour)
+    {
+        Debug.Assert(face != null);
+
+        TRObjectTexture texInfo = level.ObjectTextures[face.Texture];
+        TRImage tile = new(level.Images8[texInfo.Atlas].Pixels, level.Palette);
+        TRImage img = tile.Export(texInfo.Bounds);
+
+        List<Color> palette = new()
+        {
+            Color.Magenta,
+        };
+
+        palette.AddRange(data.TextureOverwrites
+            .SelectMany(o => o.Data)
+            .Where(p => p != 0)
+            .Distinct()
+            .Select(p => Color.FromArgb(data.Palette[p].Red, data.Palette[p].Green, data.Palette[p].Blue)));
+
+        img.Write((c, x, y) =>
+        {
+            c = c.A == 0 ? fillColour : c;
+            if (!palette.Contains(c))
+            {
+                palette.Add(c);
+            }
+
+            return c;
+        });
+
+        while (palette.Count < 256)
+        {
+            palette.Add(Color.Black);
+        }
+
+        List<TRColour> trPalette = new(palette.Select(c => c.ToTRColour()));
+        byte[] pixels = img.ToRGB(trPalette);
+
+        for (int i = 0; i < data.Palette.Count; i++)
+        {
+            data.Palette[i].Red = trPalette[i].Red;
+            data.Palette[i].Green = trPalette[i].Green;
+            data.Palette[i].Blue = trPalette[i].Blue;
+        }
+
+        data.TextureOverwrites.Add(new()
+        {
+            Page = texInfo.Atlas,
+            X = (byte)texInfo.Bounds.X,
+            Y = (byte)texInfo.Bounds.Y,
+            Width = (ushort)texInfo.Size.Width,
+            Height = (ushort)texInfo.Size.Height,
+            Data = pixels,
+        });
+    }
+}

--- a/src/Types/TR1/Textures/TR1EgyptTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1EgyptTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using System.Drawing;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -15,6 +16,8 @@ public class TR1EgyptTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings());
         data.RoomEdits.AddRange(CreateRotations());
         data.RoomEdits.AddRange(CreateShifts(egypt));
+
+        FixTransparentTextures(egypt, data);
 
         return new() { data };
     }
@@ -76,5 +79,13 @@ public class TR1EgyptTextureBuilder : TextureBuilder
                 }
             }
         };
+    }
+
+    private static void FixTransparentTextures(TR1Level egypt, InjectionData data)
+    {
+        TR1CommonTextureBuilder.FixTransparentPixels(egypt, data,
+            egypt.Rooms[25].Mesh.Rectangles[32], Color.FromArgb(188, 140, 64));
+        TR1CommonTextureBuilder.FixTransparentPixels(egypt, data,
+            egypt.Rooms[39].Mesh.Rectangles[125], Color.FromArgb(188, 140, 64));
     }
 }

--- a/src/Types/TR1/Textures/TR1KhamoonTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1KhamoonTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using System.Drawing;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -16,6 +17,8 @@ public class TR1KhamoonTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings());
         data.RoomEdits.AddRange(CreateRotations());
         data.RoomEdits.AddRange(CreateVertexShifts(khamoon));
+
+        FixTransparentTextures(khamoon, data);
 
         return new() { data };
     }
@@ -101,5 +104,13 @@ public class TR1KhamoonTextureBuilder : TextureBuilder
                 VertexChange = new() { Y = -768 }
             }
         };
+    }
+
+    private static void FixTransparentTextures(TR1Level khamoon, InjectionData data)
+    {
+        TR1CommonTextureBuilder.FixTransparentPixels(khamoon, data,
+            khamoon.Rooms[20].Mesh.Rectangles[77], Color.FromArgb(188, 140, 64));
+        TR1CommonTextureBuilder.FixTransparentPixels(khamoon, data,
+            khamoon.Rooms[20].Mesh.Rectangles[78], Color.FromArgb(188, 140, 64));
     }
 }

--- a/src/Types/TR1/Textures/TR1ObeliskTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1ObeliskTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using System.Drawing;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -16,6 +17,7 @@ public class TR1ObeliskTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
 
         FixCityGaps(obelisk, data);
+        FixTransparentTextures(obelisk, data);
 
         return new() { data };
     }
@@ -241,5 +243,19 @@ public class TR1ObeliskTextureBuilder : TextureBuilder
                 });
             }
         }
+    }
+
+    private static void FixTransparentTextures(TR1Level obelisk, InjectionData data)
+    {
+        TR1CommonTextureBuilder.FixTransparentPixels(obelisk, data,
+            obelisk.Rooms[31].Mesh.Rectangles[30], Color.FromArgb(188, 140, 64));
+        TR1CommonTextureBuilder.FixTransparentPixels(obelisk, data,
+            obelisk.Rooms[37].Mesh.Rectangles[79], Color.FromArgb(188, 140, 64));
+
+        List<ushort> verts = new() { 2, 6, 8, 11 };
+        TRMeshFace face = obelisk.StaticMeshes[TR1Type.Furniture1].Mesh
+            .TexturedRectangles.Find(t => t.Vertices.All(verts.Contains));
+
+        TR1CommonTextureBuilder.FixTransparentPixels(obelisk, data, face, Color.FromArgb(200, 144, 88));
     }
 }

--- a/src/Types/TR1/Textures/TR1ToQTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1ToQTextureBuilder.cs
@@ -16,6 +16,8 @@ public class TR1ToQTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
         data.RoomEdits.AddRange(CreateShifts(toq));
 
+        TR1CommonTextureBuilder.FixWolfTransparency(toq, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR1/Textures/TR1ValleyTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1ValleyTextureBuilder.cs
@@ -18,6 +18,8 @@ public class TR1ValleyTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateShifts(valley));
         data.RoomEdits.AddRange(CreateVertexShifts(valley));
 
+        TR1CommonTextureBuilder.FixWolfTransparency(valley, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR1/Textures/TR1VilcabambaTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1VilcabambaTextureBuilder.cs
@@ -16,6 +16,9 @@ public class TR1VilcabambaTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings());
         data.RoomEdits.AddRange(CreateRotations());
 
+        TR1CommonTextureBuilder.FixBatTransparency(vilcabamba, data);
+        TR1CommonTextureBuilder.FixWolfTransparency(vilcabamba, data);
+
         return new() { data };
     }
 


### PR DESCRIPTION
Fixes transparent bat and wolf eyes in Peru, and fills in incorrect transparent pixels on some Egypt textures (see https://github.com/LostArtefacts/TRX/discussions/736#discussioncomment-10208350).