### PR TITLE
Fix Obelisk mesh positions

### DIFF
--- a/src/Actions/TRFrameRotEdit.cs
+++ b/src/Actions/TRFrameRotEdit.cs
@@ -1,0 +1,32 @@
+﻿using TRLevelControl;
+using TRLevelControl.Model;
+
+namespace TRXInjectionTool.Actions;
+
+public class TRFrameRotEdit
+{
+    // Temporary measure until further frame re-handling engine side i.e. to target
+    // specific frame and rot indices.
+
+    public uint ModelID { get; set; }
+    public int AnimIndex { get; set; }
+    public TRVertex Rotation { get; set; }
+
+    public void Serialize(TRLevelWriter writer)
+    {
+        writer.Write(ModelID);
+        writer.Write(AnimIndex);        
+        writer.Write(PackYZRotation(Rotation.Y, Rotation.Z));
+        writer.Write(PackXYRotation(Rotation.X, Rotation.Y));
+    }
+
+    private static short PackXYRotation(int x, int y)
+    {
+        return (short)((x << 4) | ((y & 0x0FC0) >> 6));
+    }
+
+    private static short PackYZRotation(int y, int z)
+    {
+        return (short)(((y & 0x003F) << 10) | (z & 0x03FF));
+    }
+}

--- a/src/Control/InjectionData.cs
+++ b/src/Control/InjectionData.cs
@@ -32,6 +32,7 @@ public class InjectionData
     public List<TRVisPortalEdit> VisPortalEdits { get; set; } = new();
     public List<TRAnimRangeEdit> AnimRangeEdits { get; set; } = new();
     public List<TRItemEdit> ItemEdits { get; set; } = new();
+    public List<TRFrameRotEdit> FrameRots { get; set; } = new();
 
     private InjectionData() { }
 

--- a/src/Control/InjectionIO.cs
+++ b/src/Control/InjectionIO.cs
@@ -13,7 +13,7 @@ public static class InjectionIO
         [LC.Model.TRGameVersion.TR1] = new()
         {
             Magic = MakeTag('T', '1', 'M', 'J'),
-            Iteration = 9,
+            Iteration = 10,
         },
         [LC.Model.TRGameVersion.TR2] = new()
         {
@@ -103,6 +103,7 @@ public static class InjectionIO
             writer.Write((uint)data.VisPortalEdits.Count);
             writer.Write((uint)data.AnimRangeEdits.Count);
             writer.Write((uint)data.ItemEdits.Count);
+            writer.Write((uint)data.FrameRots.Count);
         }
 
         {
@@ -135,6 +136,7 @@ public static class InjectionIO
             data.VisPortalEdits.ForEach(v => v.Serialize(writer));
             data.AnimRangeEdits.ForEach(a => a.Serialize(writer));
             data.ItemEdits.ForEach(i => i.Serialize(writer));
+            data.FrameRots.ForEach(f => f.Serialize(writer));
         }
     }
 

--- a/src/Types/ItemBuilder.cs
+++ b/src/Types/ItemBuilder.cs
@@ -34,4 +34,29 @@ public abstract class ItemBuilder : InjectionBuilder
             },
         };
     }
+
+    public static TRMeshEdit FixEgyptToppledChair(TR1Type type, TR1Level level)
+    {
+        TRMesh mesh = level.StaticMeshes[type].Mesh;
+        TRMeshEdit edit = new()
+        {
+            ModelID = (uint)type,
+            MeshIndex = 0,
+            VertexEdits = new(),
+        };
+
+        for (short i = 0; i < mesh.Vertices.Count; i++)
+        {
+            edit.VertexEdits.Add(new()
+            {
+                Index = i,
+                Change = new()
+                {
+                    Y = 66,
+                }
+            });
+        }
+
+        return edit;
+    }
 }

--- a/src/Types/TR1/Items/TR1CatItemBuilder.cs
+++ b/src/Types/TR1/Items/TR1CatItemBuilder.cs
@@ -9,6 +9,16 @@ public class TR1CatItemBuilder : ItemBuilder
     public override List<InjectionData> Build()
     {
         TR1Level cat = _control1.Read($"Resources/{TR1LevelNames.CAT}");
+
+        return new()
+        {
+            CreateItemRots(cat),
+            FixMeshPositions(cat),
+        };
+    }
+
+    private static InjectionData CreateItemRots(TR1Level cat)
+    {
         InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.ItemRotation, "cat_itemrots");
 
         data.ItemEdits = new()
@@ -18,6 +28,15 @@ public class TR1CatItemBuilder : ItemBuilder
             SetAngle(cat, 171, -32768),
         };
 
-        return new() { data };
+        return data;
+    }
+
+    private static InjectionData FixMeshPositions(TR1Level cat)
+    {
+        InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.General, "cat_meshfixes");
+
+        data.MeshEdits.Add(FixEgyptToppledChair(TR1Type.Architecture7, cat));
+
+        return data;
     }
 }

--- a/src/Types/TR1/Items/TR1EgyptItemBuilder.cs
+++ b/src/Types/TR1/Items/TR1EgyptItemBuilder.cs
@@ -1,0 +1,27 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR1.Items;
+
+public class TR1EgyptItemBuilder : ItemBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR1Level egypt = _control1.Read($"Resources/{TR1LevelNames.EGYPT}");
+
+        return new()
+        {
+            FixMeshPositions(egypt),
+        };
+    }
+
+    private static InjectionData FixMeshPositions(TR1Level egypt)
+    {
+        InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.General, "egypt_meshfixes");
+
+        data.MeshEdits.Add(FixEgyptToppledChair(TR1Type.Architecture7, egypt));
+
+        return data;
+    }
+}

--- a/src/Types/TR1/Items/TR1ObeliskItemBuilder.cs
+++ b/src/Types/TR1/Items/TR1ObeliskItemBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using TRLevelControl.Helpers;
 using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR1.Items;
@@ -9,6 +10,16 @@ public class TR1ObeliskItemBuilder : ItemBuilder
     public override List<InjectionData> Build()
     {
         TR1Level obelisk = _control1.Read($"Resources/{TR1LevelNames.OBELISK}");
+        
+        return new()
+        {
+            CreateItemRots(obelisk),
+            FixMeshPositions(obelisk),
+        };
+    }
+
+    private static InjectionData CreateItemRots(TR1Level obelisk)
+    {
         InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.ItemRotation, "obelisk_itemrots");
 
         data.ItemEdits = new()
@@ -17,6 +28,106 @@ public class TR1ObeliskItemBuilder : ItemBuilder
             SetAngle(obelisk, 17, -16384),
         };
 
-        return new() { data };
+        return data;
+    }
+
+    private static InjectionData FixMeshPositions(TR1Level obelisk)
+    {
+        InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.General, "obelisk_meshfixes");
+
+        FixBridge(obelisk, data);
+        FixStatics(obelisk, data);
+
+        return data;
+    }
+
+    private static void FixBridge(TR1Level obelisk, InjectionData data)
+    {
+        TRMesh mesh = obelisk.Models[TR1Type.LiftingDoor].Meshes[0];
+        TRMeshEdit bridgeEdit = new()
+        {
+            ModelID = (uint)TR1Type.LiftingDoor,
+            MeshIndex = 0,
+            VertexEdits = new(),
+        };
+        data.MeshEdits.Add(bridgeEdit);
+
+        // Make the bridge flush with the floor when it's open, and extend it to touch
+        // the wall behind the artefacts.
+        short minY = mesh.Vertices.Min(v => v.Y);
+        for (short i = 0; i < mesh.Vertices.Count; i++)
+        {
+            bridgeEdit.VertexEdits.Add(new()
+            {
+                Index = i,
+                Change = new()
+                {
+                    Y = (short)(mesh.Vertices[i].Y == minY ? -5 : 0),
+                    Z = -1,
+                }
+            });
+        }
+
+        // Rotate the bridge completely 90 degress when open. OG is 255 ~= 89.6.
+        data.FrameRots.Add(new()
+        {
+            ModelID = (uint)TR1Type.LiftingDoor,
+            AnimIndex = 3,
+            Rotation = new() { X = 256 },
+        });
+    }
+
+    private static void FixStatics(TR1Level obelisk, InjectionData data)
+    {
+        {
+            // Move the artefact stands down slightly and push them against the wall.
+            TRMesh mesh = obelisk.StaticMeshes[TR1Type.Debris1].Mesh;
+            TRMeshEdit edit = new()
+            {
+                ModelID = (uint)TR1Type.Debris1,
+                MeshIndex = 0,
+                VertexEdits = new(),
+            };
+            data.MeshEdits.Add(edit);
+
+            for (short i = 0; i < mesh.Vertices.Count; i++)
+            {
+                edit.VertexEdits.Add(new()
+                {
+                    Index = i,
+                    Change = new()
+                    {
+                        Y = 5,
+                        Z = -13,
+                    }
+                });
+            }
+        }
+
+        {
+            // Move the senet table up
+            TRMesh mesh = obelisk.StaticMeshes[TR1Type.Furniture1].Mesh;
+            TRMeshEdit edit = new()
+            {
+                ModelID = (uint)TR1Type.Furniture1,
+                MeshIndex = 0,
+                VertexEdits = new(),
+            };
+            data.MeshEdits.Add(edit);
+
+            for (short i = 0; i < mesh.Vertices.Count; i++)
+            {
+                edit.VertexEdits.Add(new()
+                {
+                    Index = i,
+                    Change = new()
+                    {
+                        Y = -30,
+                    }
+                });
+            }
+        }
+
+        data.MeshEdits.Add(FixEgyptToppledChair(TR1Type.Furniture3, obelisk));
     }
 }


### PR DESCRIPTION
Fixes for Obelisk of Khamoon:
- Fixes the drawbridge angle and some of its vertices
- Shifts the artefact holder mesh slightly to avoid clashing with the open bridges
- Shifts the vertices on the senet table and toppled chair in room 57

Toppled chair also fixed in Return to Egypt and Temple of the Cat.
