### PR TITLE
Fix Natla's Mines boat z-fighting

### DIFF
--- a/src/Types/ItemBuilder.cs
+++ b/src/Types/ItemBuilder.cs
@@ -59,4 +59,18 @@ public abstract class ItemBuilder : InjectionBuilder
 
         return edit;
     }
+
+    public static TRVertexEdit CreateVertexShift(short index, short x = 0, short y = 0, short z = 0)
+    {
+        return new()
+        {
+            Index = index,
+            Change = new()
+            {
+                X = x,
+                Y = y,
+                Z = z,
+            }
+        };
+    }
 }

--- a/src/Types/TR1/Items/TR1MinesItemBuilder.cs
+++ b/src/Types/TR1/Items/TR1MinesItemBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using TRLevelControl.Helpers;
 using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR1.Items;
@@ -9,6 +10,16 @@ public class TR1MinesItemBuilder : ItemBuilder
     public override List<InjectionData> Build()
     {
         TR1Level mines = _control1.Read($"Resources/{TR1LevelNames.MINES}");
+
+        return new()
+        {
+            CreateItemRots(mines),
+            FixMeshPositions(),
+        };
+    }
+
+    private static InjectionData CreateItemRots(TR1Level mines)
+    {
         InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.ItemRotation, "mines_itemrots");
 
         data.ItemEdits = new()
@@ -16,6 +27,49 @@ public class TR1MinesItemBuilder : ItemBuilder
             SetAngle(mines, 71, 16384),
         };
 
-        return new() { data };
+        return data;
+    }
+
+    private static InjectionData FixMeshPositions()
+    {
+        InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.General, "mines_meshfixes");
+
+        // Shift the bottom of the motorboat down to fix z-fighting with the water.
+        {
+            TRMeshEdit edit = new()
+            {
+                ModelID = (uint)TR1Type.Furniture0,
+                MeshIndex = 0,
+                VertexEdits = new(),
+            };
+            data.MeshEdits.Add(edit);
+
+            for (short i = 16; i < 20; i++)
+            {
+                edit.VertexEdits.Add(CreateVertexShift(i, y: 3));
+            }
+        }
+
+        {
+            TRMeshEdit edit = new()
+            {
+                ModelID = (uint)TR1Type.Furniture1,
+                MeshIndex = 0,
+                VertexEdits = new(),
+            };
+            data.MeshEdits.Add(edit);
+
+            for (short i = 3; i < 6; i++)
+            {
+                edit.VertexEdits.Add(CreateVertexShift(i, y: 1));
+            }
+
+            foreach (short i in new short[] { 0, 2, 3, 5 })
+            {
+                edit.VertexEdits.Add(CreateVertexShift(i, x: 8));
+            }
+        }
+
+        return data;
     }
 }


### PR DESCRIPTION
This shifts vertices on the boat static meshes in Natla's Mines to fix z-fighting with the water texture.