### PR TITLE
Add bird guardian end level builder

### DIFF
--- a/src/Actions/TRAnimCmdEdit.cs
+++ b/src/Actions/TRAnimCmdEdit.cs
@@ -1,0 +1,21 @@
+﻿using TRLevelControl;
+
+namespace TRXInjectionTool.Actions;
+
+public class TRAnimCmdEdit
+{
+    // This relies on setup defining the raw list of commands. This action
+    // will then update the correspoding animation to point to the new list.
+    public int TypeID { get; set; }
+    public int AnimIndex { get; set; }
+    public int RawCount { get; set; }
+    public int TotalCount { get; set; }
+
+    public void Serialize(TRLevelWriter writer)
+    {
+        writer.Write(TypeID);
+        writer.Write(AnimIndex);
+        writer.Write(RawCount);
+        writer.Write(TotalCount);
+    }
+}

--- a/src/Control/Chunk.cs
+++ b/src/Control/Chunk.cs
@@ -57,4 +57,5 @@ public enum BlockType
     CameraEdits     = 24,
     FrameEdits      = 25,
     StaticEdits     = 26,
+    AnimCmdEdits    = 27,
 }

--- a/src/Control/InjectionData.cs
+++ b/src/Control/InjectionData.cs
@@ -37,6 +37,7 @@ public class InjectionData
     public List<TRVisPortalEdit> VisPortalEdits { get; set; } = new();
     public List<TRItemEdit> ItemEdits { get; set; } = new();
     public List<TRFrameRotEdit> FrameEdits { get; set; } = new();
+    public List<TRAnimCmdEdit> AnimCmdEdits { get; set; } = new();
     public List<TRCameraEdit> CameraEdits { get; set; } = new();
 
     private InjectionData() { }

--- a/src/Control/InjectionIO.cs
+++ b/src/Control/InjectionIO.cs
@@ -244,6 +244,9 @@ public static class InjectionIO
         blockCount += WriteBlock(BlockType.FrameEdits, data.FrameEdits.Count, writer,
             s => data.FrameEdits.ForEach(f => f.Serialize(s)));
 
+        blockCount += WriteBlock(BlockType.AnimCmdEdits, data.AnimCmdEdits.Count, writer,
+            s => data.AnimCmdEdits.ForEach(c => c.Serialize(s)));
+
         return blockCount;
     }
 

--- a/src/Types/TR2/Misc/TR2GuardianBuilder.cs
+++ b/src/Types/TR2/Misc/TR2GuardianBuilder.cs
@@ -1,0 +1,50 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Misc;
+
+public class TR2GuardianBuilder  : InjectionBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level palace = _control2.Read($"Resources/{TR2LevelNames.CHICKEN}");
+        TRModel guardian = palace.Models[TR2Type.BirdMonster];
+        ResetLevel(palace);
+        palace.Models[TR2Type.BirdMonster] = guardian;
+
+        TRAnimation deathAnim = guardian.Animations[20];
+        guardian.Animations.ForEach(a =>
+        {
+            if (a != deathAnim)
+            {
+                a.Commands.Clear();
+            }
+        });
+
+        deathAnim.Commands.Add(new TRFXCommand
+        {
+            FrameNumber = deathAnim.FrameEnd,
+            EffectID = (short)TR2FX.EndLevel,
+        });
+
+        // Compile the commands into flat TR format.
+        // We only want the commands, so remove all other model data.
+        InjectionData data = InjectionData.Create(palace, InjectionType.General, "guardian_death_commands", true);
+        data.Animations.Clear();
+        data.AnimFrames.Clear();
+        data.AnimChanges.Clear();
+        data.AnimDispatches.Clear();
+        data.Models.Clear();
+
+        data.AnimCmdEdits.Add(new()
+        {
+            TypeID = (int)TR2Type.BirdMonster,
+            AnimIndex = 20,
+            RawCount = data.AnimCommands.Count,
+            TotalCount = deathAnim.Commands.Count,
+        });
+
+        return new() { data };
+    }
+}


### PR DESCRIPTION
This allows for injections to replace a specific animation's set of commands, and in this case we do so to have the bird guardian end the level on the final frame of its death animation.