### PR TITLE
Fix invalid portals in The Deck

### DIFF
--- a/src/Types/FDBuilder.cs
+++ b/src/Types/FDBuilder.cs
@@ -140,4 +140,26 @@ public abstract class FDBuilder : InjectionBuilder
             }
         };
     }
+
+    protected static TRVisPortalEdit DeletePortal<R>(List<R> rooms, int baseRoomIndex, int portalIndex)
+        where R : TRRoom
+    {
+        // "Nullify" the vertices - the game will then disable the portal.
+        var portal = rooms[baseRoomIndex].Portals[portalIndex];
+        return new()
+        {
+            BaseRoom = (short)baseRoomIndex,
+            LinkRoom = (short)portal.AdjoiningRoom,
+            PortalIndex = (ushort)portalIndex,
+            VertexChanges = rooms[baseRoomIndex].Portals[portalIndex].Vertices.Select(v =>
+            {
+                return new TRVertex
+                {
+                    X = (short)-v.X,
+                    Y = (short)-v.Y,
+                    Z = (short)-v.Z,
+                };
+            }).ToList(),
+        };
+    }
 }

--- a/src/Types/TR2/FD/TR2DeckFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2DeckFDBuilder.cs
@@ -1,0 +1,20 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.FD;
+
+public class TR2DeckFDBuilder : FDBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        TR2Level deck = _control2.Read($"Resources/{TR2LevelNames.DECK}");
+        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.FDFix, "deck_fd");
+        CreateDefaultTests(data, TR2LevelNames.DECK);
+
+        data.VisPortalEdits.Add(DeletePortal(deck.Rooms, 17, 2));
+        data.VisPortalEdits.Add(DeletePortal(deck.Rooms, 104, 2));
+
+        return new() { data };
+    }
+}


### PR DESCRIPTION
This disables the portals between rooms 17 and 104 to avoid Lara seeing enemies in disconnected rooms.