### PR TITLE
Generate 8-bit in TR2

### DIFF
--- a/src/Types/TR2/FD/TR2VegasFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2VegasFDBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using TRLevelControl.Helpers;
 using TRLevelControl.Model;
-using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR2.FD;

--- a/src/Types/TR2/Misc/TR2BoatBitsBuilder.cs
+++ b/src/Types/TR2/Misc/TR2BoatBitsBuilder.cs
@@ -1,4 +1,6 @@
-﻿using TRImageControl.Packing;
+﻿using System.Drawing;
+using TRImageControl;
+using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Control;
@@ -17,6 +19,7 @@ public class TR2BoatBitsBuilder : InjectionBuilder
         var regions = packer.GetMeshRegions(boatBits.Meshes).Values.SelectMany(v => v);
         List<TRObjectTexture> originalInfos = new(venice.ObjectTextures);
 
+        List<Color> basePalette = new(venice.Palette.Select(c => c.ToTR1Color()));
         ResetLevel(venice, 1);
 
         packer = new(venice);
@@ -32,6 +35,8 @@ public class TR2BoatBitsBuilder : InjectionBuilder
             {
                 f.Texture = (ushort)venice.ObjectTextures.IndexOf(originalInfos[f.Texture]);
             });
+
+        GenerateImages8(venice, basePalette);
 
         _control2.Write(venice, MakeOutputPath(TRGameVersion.TR2, "Debug/BoatBits.tr2"));
         InjectionData data = InjectionData.Create(venice, InjectionType.TextureFix, "boat_bits", false);

--- a/src/Types/TR2/Misc/TR2FontBuilder.cs
+++ b/src/Types/TR2/Misc/TR2FontBuilder.cs
@@ -78,12 +78,13 @@ public class TR2FontBuilder : InjectionBuilder
             });
         }
 
+        List<Color> basePalette = new(wall.Palette.Select(c => c.ToTR1Color()));
         ResetLevel(wall, 1);
         TR2TexturePacker packer = new(wall);
         packer.AddRectangles(regions);
         packer.Pack(true);
 
-        GenerateImages8(wall);
+        GenerateImages8(wall, basePalette);
 
         wall.Sprites[TR2Type.FontGraphics_S_H] = font;
 

--- a/src/Types/TR2/Misc/TR2PickupScaleBuilder.cs
+++ b/src/Types/TR2/Misc/TR2PickupScaleBuilder.cs
@@ -1,4 +1,6 @@
-﻿using System.Numerics;
+﻿using System.Drawing;
+using System.Numerics;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
@@ -279,6 +281,7 @@ public class TR2PickupScaleBuilder : InjectionBuilder
         var regions = packer.GetMeshRegions(models.Values.SelectMany(m => m.Meshes)).Values.SelectMany(v => v);
         List<TRObjectTexture> originalInfos = new(level.ObjectTextures);
 
+        List<Color> basePalette = new(level.Palette.Select(c => c.ToTR1Color()));
         ResetLevel(level, 1);
 
         packer = new(level);
@@ -296,6 +299,7 @@ public class TR2PickupScaleBuilder : InjectionBuilder
                 f.Texture = (ushort)level.ObjectTextures.IndexOf(originalInfos[f.Texture]);
             });
 
+        GenerateImages8(level, basePalette);
         return InjectionData.Create(level, InjectionType.General, binName);
     }
 

--- a/src/Types/TR2/Textures/TR2Cut4TextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2Cut4TextureBuilder.cs
@@ -1,4 +1,6 @@
-﻿using TRImageControl.Packing;
+﻿using System.Drawing;
+using TRImageControl;
+using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Control;
@@ -26,6 +28,7 @@ public class TR2Cut4TextureBuilder : TextureBuilder
         var n = regions.SelectMany(r => r.Segments.Select(s => s.Index));
         List<TRObjectTexture> originalInfos = new(cut4.ObjectTextures);
         
+        List<Color> basePalette = new(cut4.Palette.Select(c => c.ToTR1Color()));
         ResetLevel(cut4, 1);
 
         packer = new(cut4);
@@ -41,6 +44,8 @@ public class TR2Cut4TextureBuilder : TextureBuilder
                 TRObjectTexture t = originalInfos[f.Texture];
                 f.Texture = (ushort)cut4.ObjectTextures.IndexOf(t);
             });
+
+        GenerateImages8(cut4, basePalette);
 
         _control2.Write(cut4, MakeOutputPath(TRGameVersion.TR2, "Debug/cut4.tr2"));
 


### PR DESCRIPTION
Added missing calls to generate 8-bit textures for TR2, and updated the algorithm to ensure we don't exceed 256 colours.