### PR TITLE
Fix TR1 sprite alignment

### DIFF
--- a/src/Actions/TRSpriteEdit.cs
+++ b/src/Actions/TRSpriteEdit.cs
@@ -1,0 +1,19 @@
+﻿using TRLevelControl;
+using TRLevelControl.Model;
+
+namespace TRXInjectionTool.Actions;
+
+public class TRSpriteEdit
+{
+    public int ID { get; set; }
+    public TRSpriteAlignment Alignment { get; set; }
+
+    public void Serialize(TRLevelWriter writer)
+    {
+        writer.Write(ID);
+        writer.Write(Alignment.Left);
+        writer.Write(Alignment.Top);
+        writer.Write(Alignment.Right);        
+        writer.Write(Alignment.Bottom);
+    }
+}

--- a/src/Control/Chunk.cs
+++ b/src/Control/Chunk.cs
@@ -58,4 +58,5 @@ public enum BlockType
     FrameEdits      = 25,
     StaticEdits     = 26,
     AnimCmdEdits    = 27,
+    SpriteEdit      = 28,
 }

--- a/src/Control/InjectionData.cs
+++ b/src/Control/InjectionData.cs
@@ -39,6 +39,7 @@ public class InjectionData
     public List<TRFrameRotEdit> FrameEdits { get; set; } = new();
     public List<TRAnimCmdEdit> AnimCmdEdits { get; set; } = new();
     public List<TRCameraEdit> CameraEdits { get; set; } = new();
+    public List<TRSpriteEdit> SpriteEdits { get; set; } = new();
 
     private InjectionData() { }
 

--- a/src/Control/InjectionIO.cs
+++ b/src/Control/InjectionIO.cs
@@ -247,6 +247,9 @@ public static class InjectionIO
         blockCount += WriteBlock(BlockType.AnimCmdEdits, data.AnimCmdEdits.Count, writer,
             s => data.AnimCmdEdits.ForEach(c => c.Serialize(s)));
 
+        blockCount += WriteBlock(BlockType.SpriteEdit, data.SpriteEdits.Count, writer,
+            s => data.SpriteEdits.ForEach(c => c.Serialize(s)));
+
         return blockCount;
     }
 

--- a/src/Types/TR1/Misc/TR1PickupSpriteBuilder.cs
+++ b/src/Types/TR1/Misc/TR1PickupSpriteBuilder.cs
@@ -1,0 +1,40 @@
+﻿using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR1.Misc;
+
+public  class TR1PickupSpriteBuilder : InjectionBuilder
+{
+    private static readonly Dictionary<TR1Type, TRSpriteAlignment> _alignmentFixes = new()
+    {
+        [TR1Type.Pistols_S_P]
+            = new() { Left = -144, Top = -84, Right = 144, Bottom = 28, },
+        [TR1Type.Shotgun_S_P]
+            = new() { Left = -240, Top = -96, Right = 240, Bottom = 0, },
+        [TR1Type.Magnums_S_P]
+            = new() { Left = -152, Top = -130, Right = 152, Bottom = 14, },
+        [TR1Type.Uzis_S_P]
+            = new() { Left = -128, Top = -88, Right = 128, Bottom = 24, },
+        [TR1Type.ShotgunAmmo_S_P]
+            = new() { Left = -136, Top = -96, Right = 136, Bottom = 0, },
+        [TR1Type.MagnumAmmo_S_P]
+            = new() { Left = -120, Top = -104, Right = 120, Bottom = 8, },
+        [TR1Type.SmallMed_S_P]
+            = new() { Left = -88, Top = -88, Right = 88, Bottom = 22, },
+    };
+
+    public override List<InjectionData> Build()
+    {
+        InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.General, "sprite_alignment");
+        data.SpriteEdits.AddRange(_alignmentFixes.Select(a =>
+        {
+            return new TRSpriteEdit
+            {
+                ID = (int)a.Key,
+                Alignment = a.Value,
+            };
+        }));
+        return new() { data };
+    }
+}

--- a/src/Types/TR1/Textures/TR1CatTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1CatTextureBuilder.cs
@@ -17,6 +17,7 @@ public class TR1CatTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateFillers(cat));
         data.RoomEdits.AddRange(CreateRefacings());
         data.RoomEdits.AddRange(CreateRotations());
+        data.RoomEdits.AddRange(FixVases(cat));
 
         FixTransparentTextures(cat, data);
 
@@ -89,6 +90,17 @@ public class TR1CatTextureBuilder : TextureBuilder
             Rotate(96, TRMeshFaceType.TexturedQuad, 73, 3),
             Rotate(96, TRMeshFaceType.TexturedQuad, 27, 1),
         };
+    }
+
+    private static IEnumerable<TRRoomVertexMove> FixVases(TR1Level cat)
+    {
+        return cat.Rooms
+            .SelectMany(r => r.Mesh.Sprites.Where(s => s.ID == TR1Type.Debris0).Select(s => new TRRoomVertexMove
+            {
+                RoomIndex = (short)cat.Rooms.IndexOf(r),
+                VertexIndex = (ushort)s.Vertex,
+                VertexChange = new() { Y = -27 },
+            }));
     }
 
     private static void FixTransparentTextures(TR1Level cat, InjectionData data)

--- a/src/Types/TR1/Textures/TR1EgyptTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1EgyptTextureBuilder.cs
@@ -17,6 +17,7 @@ public class TR1EgyptTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings());
         data.RoomEdits.AddRange(CreateRotations());
         data.RoomEdits.AddRange(CreateShifts(egypt));
+        data.RoomEdits.AddRange(FixVases(egypt));
 
         FixTransparentTextures(egypt, data);
 
@@ -80,6 +81,17 @@ public class TR1EgyptTextureBuilder : TextureBuilder
                 }
             }
         };
+    }
+
+    private static IEnumerable<TRRoomVertexMove> FixVases(TR1Level egypt)
+    {
+        return egypt.Rooms
+            .SelectMany(r => r.Mesh.Sprites.Where(s => s.ID == TR1Type.Debris0).Select(s => new TRRoomVertexMove
+            {
+                RoomIndex = (short)egypt.Rooms.IndexOf(r),
+                VertexIndex = (ushort)s.Vertex,
+                VertexChange = new() { Y = -27 },
+            }));
     }
 
     private static void FixTransparentTextures(TR1Level egypt, InjectionData data)


### PR DESCRIPTION
Adds support for injecting sprite alignment adjustments, and fixes pickup sprites in TR1 and vase room sprites in TRUB.