### PR TITLE
Fix Ice Palace zoning

### DIFF
--- a/src/Actions/TRFloorDataEdit.cs
+++ b/src/Actions/TRFloorDataEdit.cs
@@ -32,6 +32,7 @@ public enum FDFixType
     TrigType,
     SectorOverwrite,
     GlideCameraFix,
+    ZoneFix,
 }
 
 public abstract class FDFix
@@ -165,6 +166,20 @@ public class FDSectorOverwrite : FDFix
         writer.Write(Sector.Floor);
         writer.Write(Sector.RoomAbove);
         writer.Write(Sector.Ceiling);
+    }
+}
+
+public class FDZoneFix : FDFix
+{
+    public override FDFixType FixType => FDFixType.ZoneFix;
+    public TRZoneGroup ZoneOverwrite { get; set; }
+
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
+    {
+        writer.Write(ZoneOverwrite.FlipOffZone.Ground.Values);
+        writer.Write(ZoneOverwrite.FlipOffZone.Fly);
+        writer.Write(ZoneOverwrite.FlipOnZone.Ground.Values);
+        writer.Write(ZoneOverwrite.FlipOnZone.Fly);
     }
 }
 

--- a/src/Types/TR2/FD/TR2IcePalaceFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2IcePalaceFDBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR2.FD;
@@ -22,6 +23,31 @@ public class TR2IcePalaceFDBuilder : FDBuilder
         FDTriggerEntry hammerTrigger = GetTrigger(palace, 29, 4, 6);
         data.FloorEdits.Add(MakeTrigger(palace, 29, 3, 6, hammerTrigger));
 
+        data.FloorEdits.Add(FixZoning(palace));
+
         return new() { data };
+    }
+
+    private static TRFloorDataEdit FixZoning(TR2Level palace)
+    {
+        // Box 377 is in room 48, which isn't part of the flipmap, but it also spills
+        // into room 45 which has flip room 110. The original editor appears to have not
+        // recognised this and so the box's flip zone infers there is no zone link.
+        TRRoomSector sector = palace.Rooms[48].GetSector(5, 4, TRUnit.Sector);
+        TRZoneGroup zone = palace.Boxes[sector.BoxIndex].Zone;
+        zone.FlipOnZone = zone.FlipOffZone.Clone();
+        return new()
+        {
+            RoomIndex = 48,
+            X = 5,
+            Z = 4,
+            Fixes = new()
+            {
+                new FDZoneFix
+                {
+                    ZoneOverwrite = zone,
+                },
+            },
+        };
     }
 }


### PR DESCRIPTION
This adds functionality to replace a particular box's zoning data, and is used to fix the zones in Ice Palace near the start where the yetis can get stuck.