### PR TITLE
Adjust TR2 music triggers

### DIFF
--- a/src/InjectionBuilder.cs
+++ b/src/InjectionBuilder.cs
@@ -4,6 +4,7 @@ using TRDataControl;
 using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Applicability;
 using TRXInjectionTool.Control;
@@ -294,4 +295,32 @@ public abstract class InjectionBuilder
         Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
         return fullPath;
     }
+
+    protected static readonly Dictionary<string, string> _tr2NameMap = new()
+    {
+        [TR2LevelNames.ASSAULT] = "gym",
+        [TR2LevelNames.GW] = "wall",
+        [TR2LevelNames.VENICE] = "venice",
+        [TR2LevelNames.BARTOLI] = "bartoli",
+        [TR2LevelNames.OPERA] = "opera",
+        [TR2LevelNames.RIG] = "rig",
+        [TR2LevelNames.DA] = "diving",
+        [TR2LevelNames.FATHOMS] = "fathoms",
+        [TR2LevelNames.DORIA] = "wreck",
+        [TR2LevelNames.LQ] = "living",
+        [TR2LevelNames.DECK] = "deck",
+        [TR2LevelNames.TIBET] = "tibet",
+        [TR2LevelNames.MONASTERY] = "barkhang",
+        [TR2LevelNames.COT] = "catacombs",
+        [TR2LevelNames.CHICKEN] = "palace",
+        [TR2LevelNames.XIAN] = "xian",
+        [TR2LevelNames.FLOATER] = "floating",
+        [TR2LevelNames.LAIR] = "lair",
+        [TR2LevelNames.HOME] = "house",
+        [TR2LevelNames.COLDWAR] = "coldwar",
+        [TR2LevelNames.FOOLGOLD] = "fools",
+        [TR2LevelNames.FURNACE] = "furnace",
+        [TR2LevelNames.KINGDOM] = "kingdom",
+        [TR2LevelNames.VEGAS] = "vegas",
+    };
 }

--- a/src/Types/TR2/FD/TR2MusicTrackBuilder.cs
+++ b/src/Types/TR2/FD/TR2MusicTrackBuilder.cs
@@ -1,0 +1,106 @@
+﻿using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.FD;
+
+public class TR2MusicTrackBuilder : InjectionBuilder
+{
+    public override string ID => "fix-tr2-music-tracks";
+
+    public override List<InjectionData> Build()
+    {
+        var result = new List<InjectionData>();
+        foreach (var (levelName, binName) in _tr2NameMap)
+        {
+            var level = _control2.Read($"Resources/{levelName}");
+            var edits = FixMusicTriggers(level);
+            if (!edits.Any())
+            {
+                continue;
+            }
+
+            var data = InjectionData.Create(TRGameVersion.TR2, InjectionType.General, $"{binName}_music_tracks");
+            CreateDefaultTests(data, levelName);
+            data.FloorEdits.AddRange(edits);
+            result.Add(data);
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<TRFloorDataEdit> FixMusicTriggers(TR2Level level)
+    {
+        for (short r = 0; r < level.Rooms.Count; r++)
+        {
+            var room = level.Rooms[r];
+            for (ushort x = 1; x < room.NumXSectors - 1; x++)
+            {
+                for (ushort z = 1; z < room.NumZSectors - 1; z++)
+                {
+                    var sector = room.GetSector(x, z, TRUnit.Sector);
+                    if (sector.FDIndex == 0)
+                    {
+                        continue;
+                    }
+
+                    var fixes = level.FloorData[sector.FDIndex]
+                        .OfType<FDTriggerEntry>()
+                        .SelectMany(t => t.Actions.Where(a => a.Action == FDTrigAction.PlaySoundtrack))
+                        .Select(a => FixTrack(a, r, x, z))
+                        .Where(a => a != null);
+                    foreach (var fix in fixes)
+                    {
+                        yield return fix;
+                    }
+                }
+            }
+        }
+    }
+
+    private static TRFloorDataEdit FixTrack(FDActionItem action, short room, ushort x, ushort z)
+    {
+        var track = action.Parameter;
+        var realTrack = GetRealTrack(track);
+        if (track == realTrack)
+        {
+            return null;
+        }
+
+        return new()
+        {
+            RoomIndex = room,
+            X = x,
+            Z = z,
+            Fixes = new()
+            {
+                new FDTrigParamFix
+                {
+                    ActionType = FDTrigAction.PlaySoundtrack,
+                    OldParam = track,
+                    NewParam = realTrack,
+                }
+            }
+        };
+    }
+
+    private static short GetRealTrack(short trackID)
+    {
+        short[] skippedIDs = { 2, 19, 20, 26, -1 };
+        short idx = 0;
+        short result = 2;
+
+        for (int i = 2; i < trackID; i++)
+        {
+            if ((skippedIDs[idx] >= 0) && (i == skippedIDs[idx]))
+            {
+                idx++;
+            }
+            else
+            {
+                result++;
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
This amends all music triggers in TR2 to play the real track number, so trigger action parameters now match the music file names themselves.