### PR TITLE
Fix HSH shower cutscene end

### DIFF
--- a/src/Control/Chunk.cs
+++ b/src/Control/Chunk.cs
@@ -26,6 +26,7 @@ public enum ChunkType
     ObjectData    = 4,
     SFXData       = 5,
     DataEdits     = 6,
+    CameraData    = 7,
 }
 
 public enum BlockType
@@ -60,4 +61,5 @@ public enum BlockType
     AnimCmdEdits    = 27,
     SpriteEdit      = 28,
     StaticObjects   = 29,
+    CinematicFrames = 30,
 }

--- a/src/Control/InjectionData.cs
+++ b/src/Control/InjectionData.cs
@@ -30,6 +30,7 @@ public class InjectionData
     public List<TRStaticMesh> StaticObjects { get; set; } = new();
     public List<TRColour> Palette { get; set; } = new();
     public List<TRSFXData> SFX { get; set; } = new();
+    public List<TRCinematicFrame> CinematicFrames { get; set; } = new();
     public List<TRMeshEdit> MeshEdits { get; set; } = new();
     public List<TRStaticMeshEdit> StaticMeshEdits { get; set; } = new();
     public List<TRTextureOverwrite> TextureOverwrites { get; set; } = new();
@@ -116,6 +117,7 @@ public class InjectionData
             }).ToList(),
             SpriteSequences = level.SpriteSequences.ToList(),
             SpriteTextures = level.SpriteTextures.ToList(),
+            CinematicFrames = level.CinematicFrames.ToList(),
         };
 
         for (int i = 0; i < sounds.Length; i++)
@@ -185,6 +187,7 @@ public class InjectionData
             }).ToList(),
             SpriteSequences = level.SpriteSequences.ToList(),
             SpriteTextures = level.SpriteTextures.ToList(),
+            CinematicFrames = level.CinematicFrames.ToList(),
         };
 
         for (int i = 0; i < sounds.Length; i++)

--- a/src/Control/InjectionIO.cs
+++ b/src/Control/InjectionIO.cs
@@ -64,6 +64,7 @@ public static class InjectionIO
             CreateChunk(ChunkType.AnimationData, data, WriteAnimationData),
             CreateChunk(ChunkType.ObjectData, data, WriteObjectData),
             CreateChunk(ChunkType.SFXData, data, WriteSFXData),
+            CreateChunk(ChunkType.CameraData, data, WriteCameraData),
             CreateChunk(ChunkType.DataEdits, data, WriteEdits),
         };
 
@@ -208,6 +209,12 @@ public static class InjectionIO
     {
         return WriteBlock(BlockType.SampleInfos, data.SFX.Count, writer,
             s => data.SFX.ForEach(f => f.Serialize(s, data.GameVersion)));
+    }
+
+    private static int WriteCameraData(InjectionData data, TRLevelWriter writer)
+    {
+        return WriteBlock(BlockType.CinematicFrames, data.CinematicFrames.Count, writer,
+            s => data.CinematicFrames.ForEach(f => s.Write(f.Serialize())));
     }
 
     private static int WriteEdits(InjectionData data, TRLevelWriter writer)

--- a/src/InjectionBuilder.cs
+++ b/src/InjectionBuilder.cs
@@ -115,6 +115,7 @@ public abstract class InjectionBuilder
         level.Boxes.Clear();
         level.Entities.Clear();
         level.Cameras.Clear();
+        level.CinematicFrames.Clear();
 
         for (int i = 0; i < 256; i++)
         {
@@ -144,6 +145,7 @@ public abstract class InjectionBuilder
         level.Boxes.Clear();
         level.Entities.Clear();
         level.Cameras.Clear();
+        level.CinematicFrames.Clear();
 
         for (int i = 0; i < 256; i++)
         {

--- a/src/Types/TR2/Misc/TR2ShowerBuilder.cs
+++ b/src/Types/TR2/Misc/TR2ShowerBuilder.cs
@@ -1,0 +1,38 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Misc;
+
+public class TR2ShowerBuilder : InjectionBuilder
+{
+    public override string ID => "house_shower_frames";
+
+    public override List<InjectionData> Build()
+    {
+        var hsh = _control2.Read($"Resources/{TR2LevelNames.HOME}");
+        var laraExtra = hsh.Models[TR2Type.LaraMiscAnim_H];
+        var cineFrames = hsh.CinematicFrames.ToList();
+        for (int i = 1; i <= 3; i++)
+        {
+            // Get the camera out of the wall
+            cineFrames[^i].Target.X += 208;
+            cineFrames[^i].Position.X -= 144;
+        }
+        
+        ResetLevel(hsh);
+        hsh.Models[TR2Type.LaraMiscAnim_H] = laraExtra;
+        hsh.CinematicFrames = cineFrames;
+
+        TRAnimation endAnim = laraExtra.Animations[2];
+        for (int i = 0; i < 120; i++)
+        {
+            endAnim.Frames.Add(endAnim.Frames[^1]);
+            endAnim.FrameEnd++;
+            hsh.CinematicFrames.Add(cineFrames[^1]);
+        }
+
+        InjectionData data = InjectionData.Create(hsh, InjectionType.General, ID, true);
+        return new() { data };
+    }
+}


### PR DESCRIPTION
This adds cinematic frame injection support to allow extending the HSH cutscene to prevent the shotgun sound being cut off. It also rectifies the last few frames being inside the wall.