### PR TITLE
Fix Lara's windows

### DIFF
--- a/src/Types/TR2/Textures/TR2GymTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2GymTextureBuilder.cs
@@ -24,6 +24,8 @@ public class TR2GymTextureBuilder : TextureBuilder
         // Current injection limitation, do not replace SFX
         level.SoundEffects.Clear();
 
+        FixHomeWindows(level, TR2LevelNames.ASSAULT);
+
         InjectionData data = InjectionData.Create(level, InjectionType.TextureFix, ID);
         CreateDefaultTests(data, TR2LevelNames.ASSAULT);
         return data;

--- a/src/Types/TR2/Textures/TR2HSHTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2HSHTextureBuilder.cs
@@ -10,12 +10,25 @@ public class TR2HSHTextureBuilder : TextureBuilder
 
     public override List<InjectionData> Build()
     {
-        TR2Level house = _control2.Read($"Resources/{TR2LevelNames.HOME}");
-        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.TextureFix, ID);
-        CreateDefaultTests(data, TR2LevelNames.HOME);
+        InjectionData data = CreateBaseData();
 
+        TR2Level house = _control2.Read($"Resources/{TR2LevelNames.HOME}");
         FixLaraTransparency(house, data);
 
         return new() { data };
+    }
+
+    private InjectionData CreateBaseData()
+    {
+        var level = _control2.Read($"Resources/{TR2LevelNames.HOME}");
+        var palette = level.Palette.ToList();
+        ResetLevel(level, 1);
+        level.Palette = palette;
+
+        FixHomeWindows(level, TR2LevelNames.HOME);
+
+        InjectionData data = InjectionData.Create(level, InjectionType.TextureFix, ID);
+        CreateDefaultTests(data, TR2LevelNames.HOME);
+        return data;
     }
 }


### PR DESCRIPTION
This updates the smashable windows in the gym and HSH levels, replacing the flat opaque faces with textured transparent equivalents.