### PR TITLE
Fix passport texture issues

### DIFF
--- a/src/Types/TR1/Textures/TR1AtlantisTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1AtlantisTextureBuilder.cs
@@ -18,6 +18,7 @@ public class TR1AtlantisTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
         data.RoomEdits.AddRange(CreateShifts(atlantis));
         FixPlatformDoorArea(data, atlantis);
+        FixPassport(atlantis, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1CatTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1CatTextureBuilder.cs
@@ -20,6 +20,7 @@ public class TR1CatTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(FixVases(cat));
 
         FixTransparentTextures(cat, data);
+        FixPassport(cat, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1CavesTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1CavesTextureBuilder.cs
@@ -20,6 +20,7 @@ public class TR1CavesTextureBuilder : TextureBuilder
 
         FixBatTransparency(caves, data);
         FixWolfTransparency(caves, data);
+        FixPassport(caves, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1CisternTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1CisternTextureBuilder.cs
@@ -18,6 +18,7 @@ public class TR1CisternTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(cistern));
 
         FixRoom9(cistern, data);
+        FixPassport(cistern, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1ColosseumTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1ColosseumTextureBuilder.cs
@@ -21,6 +21,7 @@ public class TR1ColosseumTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
 
         FixRoofTextures(data);
+        FixPassport(colosseum, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1EgyptTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1EgyptTextureBuilder.cs
@@ -20,6 +20,7 @@ public class TR1EgyptTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(FixVases(egypt));
 
         FixTransparentTextures(egypt, data);
+        FixPassport(egypt, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1FollyTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1FollyTextureBuilder.cs
@@ -18,6 +18,8 @@ public class TR1FollyTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
         data.RoomEdits.AddRange(CreateShifts(folly));
 
+        FixPassport(folly, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR1/Textures/TR1GymTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1GymTextureBuilder.cs
@@ -16,6 +16,8 @@ public class TR1GymTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(gym));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(gym, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR1/Textures/TR1HiveTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1HiveTextureBuilder.cs
@@ -9,11 +9,14 @@ public class TR1HiveTextureBuilder : TextureBuilder
 {
     public override List<InjectionData> Build()
     {
+        TR1Level hive = _control1.Read($"Resources/{TR1LevelNames.HIVE}");
         InjectionData data = InjectionData.Create(TRGameVersion.TR1, InjectionType.TextureFix, "hive_textures");
         CreateDefaultTests(data, TR1LevelNames.HIVE);
 
         data.RoomEdits.AddRange(CreateRefacings());
         data.RoomEdits.AddRange(CreateRotations());
+
+        FixPassport(hive, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1KhamoonTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1KhamoonTextureBuilder.cs
@@ -20,6 +20,7 @@ public class TR1KhamoonTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateVertexShifts(khamoon));
 
         FixTransparentTextures(khamoon, data);
+        FixPassport(khamoon, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1MidasTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1MidasTextureBuilder.cs
@@ -19,6 +19,7 @@ public class TR1MidasTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateShifts(midas));
 
         FixRoom13(midas, data);
+        FixPassport(midas, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1MinesTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1MinesTextureBuilder.cs
@@ -19,6 +19,7 @@ public class TR1MinesTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateShifts(mines));
 
         FixEnemyTextures(data);
+        FixPassport(mines, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1ObeliskTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1ObeliskTextureBuilder.cs
@@ -19,6 +19,7 @@ public class TR1ObeliskTextureBuilder : TextureBuilder
 
         FixCityGaps(obelisk, data);
         FixTransparentTextures(obelisk, data);
+        FixPassport(obelisk, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1PyramidTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1PyramidTextureBuilder.cs
@@ -18,6 +18,7 @@ public class TR1PyramidTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
 
         FixRoom25(pyramid, data);
+        FixPassport(pyramid, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1SanctuaryTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1SanctuaryTextureBuilder.cs
@@ -18,6 +18,8 @@ public class TR1SanctuaryTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateVertexShifts(sanctuary));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(sanctuary, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR1/Textures/TR1StrongholdTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1StrongholdTextureBuilder.cs
@@ -20,6 +20,7 @@ public class TR1StrongholdTextureBuilder : TextureBuilder
 
         FixRoom13(stronghold, data);
         FixHubRoom(stronghold, data);
+        FixPassport(stronghold, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1TihocanTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1TihocanTextureBuilder.cs
@@ -16,6 +16,8 @@ public class TR1TihocanTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings());
         data.RoomEdits.AddRange(CreateShifts(tihocan));
 
+        FixPassport(tihocan, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR1/Textures/TR1TitleTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1TitleTextureBuilder.cs
@@ -1,0 +1,20 @@
+﻿using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR1.Textures;
+
+public class TR1TitleTextureBuilder : TextureBuilder
+{
+    public override string ID => "title_textures";
+
+    public override List<InjectionData> Build()
+    {
+        var level = _control1.Read($"Resources/title.phd");
+        var data = InjectionData.Create(TRGameVersion.TR1, InjectionType.TextureFix, ID);
+        CreateDefaultTests(data, "title.phd");
+
+        FixPassport(level, data);
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR1/Textures/TR1ToQTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1ToQTextureBuilder.cs
@@ -18,6 +18,7 @@ public class TR1ToQTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateShifts(toq));
 
         FixWolfTransparency(toq, data);
+        FixPassport(toq, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1ValleyTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1ValleyTextureBuilder.cs
@@ -20,6 +20,7 @@ public class TR1ValleyTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateVertexShifts(valley));
 
         FixWolfTransparency(valley, data);
+        FixPassport(valley, data);
 
         return new() { data };
     }

--- a/src/Types/TR1/Textures/TR1VilcabambaTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1VilcabambaTextureBuilder.cs
@@ -19,6 +19,7 @@ public class TR1VilcabambaTextureBuilder : TextureBuilder
 
         FixBatTransparency(vilcabamba, data);
         FixWolfTransparency(vilcabamba, data);
+        FixPassport(vilcabamba, data);
 
         return new() { data };
     }

--- a/src/Types/TR2/Textures/TR2BarkhangTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2BarkhangTextureBuilder.cs
@@ -23,6 +23,8 @@ public class TR2BarkhangTextureBuilder : TextureBuilder
         data.MeshEdits.Add(
             FixStaticMeshPosition(barkhang.StaticMeshes, TR2Type.Architecture7, new() { X = 5 }));
 
+        FixPassport(barkhang, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2BartoliTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2BartoliTextureBuilder.cs
@@ -22,6 +22,8 @@ public class TR2BartoliTextureBuilder : TextureBuilder
         data.MeshEdits.Add(
             FixStaticMeshPosition(bartoli.StaticMeshes, TR2Type.Architecture4, new() { Z = 27 }));
 
+        FixPassport(bartoli, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2CatacombsTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2CatacombsTextureBuilder.cs
@@ -20,6 +20,8 @@ public class TR2CatacombsTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2ColdWarTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2ColdWarTextureBuilder.cs
@@ -7,14 +7,17 @@ using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR2.Textures;
 
-public class TR2ColdWarTextureBuilder : InjectionBuilder
+public class TR2ColdWarTextureBuilder : TextureBuilder
 {
     public override string ID => "coldwar_textures";
 
     public override List<InjectionData> Build()
     {
+        TR2Level level = _control2.Read($"Resources/{TR2LevelNames.COLDWAR}");
         InjectionData data = CreateBaseData();
         CreateDefaultTests(data, TR2LevelNames.COLDWAR);
+
+        FixPassport(level, data);
 
         return new() { data };
     }

--- a/src/Types/TR2/Textures/TR2DeckTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2DeckTextureBuilder.cs
@@ -21,6 +21,8 @@ public class TR2DeckTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
         FixRoom80(level, data);
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2DivingTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2DivingTextureBuilder.cs
@@ -19,6 +19,8 @@ public class TR2DivingTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2FathomsTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2FathomsTextureBuilder.cs
@@ -19,6 +19,8 @@ public class TR2FathomsTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateFillers(level));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2FloatingTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2FloatingTextureBuilder.cs
@@ -21,6 +21,8 @@ public class TR2FloatingTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2FoolsTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2FoolsTextureBuilder.cs
@@ -1,0 +1,21 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Textures;
+
+public class TR2FoolsTextureBuilder : TextureBuilder
+{
+    public override string ID => "fools_textures";
+
+    public override List<InjectionData> Build()
+    {
+        var level = _control2.Read($"Resources/{TR2LevelNames.FOOLGOLD}");
+        var data = InjectionData.Create(TRGameVersion.TR2, InjectionType.TextureFix, ID);
+        CreateDefaultTests(data, TR2LevelNames.FOOLGOLD);
+
+        FixPassport(level, data);
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Textures/TR2FurnaceTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2FurnaceTextureBuilder.cs
@@ -21,6 +21,8 @@ public class TR2FurnaceTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateFillers(furnace));
         data.RoomEdits.AddRange(CreateRefacings(furnace));
 
+        FixPassport(furnace, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2GymTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2GymTextureBuilder.cs
@@ -24,6 +24,7 @@ public class TR2GymTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(gym));
         data.RoomEdits.AddRange(CreateRotations());
         ReplaceGoldIdol(data, gym);
+        FixPassport(gym, data);
 
         return new() { data };
     }

--- a/src/Types/TR2/Textures/TR2HSHTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2HSHTextureBuilder.cs
@@ -22,6 +22,8 @@ public class TR2HSHTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(house));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(house, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2IcePalaceTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2IcePalaceTextureBuilder.cs
@@ -20,6 +20,8 @@ public class TR2IcePalaceTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2KingdomTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2KingdomTextureBuilder.cs
@@ -27,6 +27,8 @@ public class TR2KingdomTextureBuilder : TextureBuilder
             }
         });
 
+        FixPassport(kingdom, data);
+
         return new() { data };
     }
 }

--- a/src/Types/TR2/Textures/TR2LairTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2LairTextureBuilder.cs
@@ -1,0 +1,21 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Textures;
+
+public class TR2LairTextureBuilder : TextureBuilder
+{
+    public override string ID => "lair_textures";
+
+    public override List<InjectionData> Build()
+    {
+        var level = _control2.Read($"Resources/{TR2LevelNames.LAIR}");
+        var data = InjectionData.Create(TRGameVersion.TR2, InjectionType.TextureFix, ID);
+        CreateDefaultTests(data, TR2LevelNames.LAIR);
+
+        FixPassport(level, data);
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Textures/TR2LivingTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2LivingTextureBuilder.cs
@@ -17,6 +17,8 @@ public class TR2LivingTextureBuilder : TextureBuilder
 
         data.RoomEdits.AddRange(CreateRefacings(level));
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2OperaTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2OperaTextureBuilder.cs
@@ -18,6 +18,8 @@ public class TR2OperaTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(opera));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(opera, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2RigTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2RigTextureBuilder.cs
@@ -20,6 +20,8 @@ public class TR2RigTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(level));
         FixThinWall(level, data);
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2TibetTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2TibetTextureBuilder.cs
@@ -19,6 +19,8 @@ public class TR2TibetTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2TitleTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2TitleTextureBuilder.cs
@@ -1,0 +1,20 @@
+﻿using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.Textures;
+
+public class TR2TitleTextureBuilder : TextureBuilder
+{
+    public override string ID => "title_textures";
+
+    public override List<InjectionData> Build()
+    {
+        var level = _control2.Read($"Resources/title.tr2");
+        var data = InjectionData.Create(TRGameVersion.TR2, InjectionType.TextureFix, ID);
+        CreateDefaultTests(data, "title.tr2");
+
+        FixPassport(level, data);
+
+        return new() { data };
+    }
+}

--- a/src/Types/TR2/Textures/TR2VegasTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2VegasTextureBuilder.cs
@@ -18,6 +18,8 @@ public class TR2VegasTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
         FixTV(level, data);
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2VeniceTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2VeniceTextureBuilder.cs
@@ -21,6 +21,8 @@ public class TR2VeniceTextureBuilder : TextureBuilder
         data.MeshEdits.Add(
             FixStaticMeshPosition(venice.StaticMeshes, TR2Type.Architecture4, new() { Z = 27 }));
 
+        FixPassport(venice, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2WallTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2WallTextureBuilder.cs
@@ -18,6 +18,8 @@ public class TR2WallTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 

--- a/src/Types/TR2/Textures/TR2WreckTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2WreckTextureBuilder.cs
@@ -20,6 +20,7 @@ public class TR2WreckTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
 
         FixTransparentPixels(level, data, level.Rooms[31].Mesh.Rectangles[23], Color.FromArgb(189, 222, 230));
+        FixPassport(level, data);
 
         return new() { data };
     }

--- a/src/Types/TR2/Textures/TR2XianTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2XianTextureBuilder.cs
@@ -21,6 +21,8 @@ public class TR2XianTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
 
+        FixPassport(level, data);
+
         return new() { data };
     }
 


### PR DESCRIPTION
Fixes z-fighting in the passport in both games, and a column of incorrect pixels in TR1's passport. Included in each level's texture fix injection, so tied to that option.