### PR TITLE
Adjust static mesh collision boxes

### DIFF
--- a/src/Types/ItemBuilder.cs
+++ b/src/Types/ItemBuilder.cs
@@ -60,6 +60,20 @@ public abstract class ItemBuilder : InjectionBuilder
         return edit;
     }
 
+    public static TRStaticMeshEdit FixEgyptPillar(TR1Level level)
+    {
+        var pillar = level.StaticMeshes[TR1Type.SceneryBase + 30];
+        pillar.CollisionBox.MinX += 64;
+        pillar.CollisionBox.MinZ += 64;
+        pillar.CollisionBox.MaxZ -= 64;
+        pillar.CollisionBox.MaxX -= 64;
+        return new()
+        {
+            TypeID = 30,
+            Mesh = pillar,
+        };
+    }
+
     public static TRVertexEdit CreateVertexShift(short index, short x = 0, short y = 0, short z = 0)
     {
         return new()

--- a/src/Types/TR1/Items/TR1CatItemBuilder.cs
+++ b/src/Types/TR1/Items/TR1CatItemBuilder.cs
@@ -44,6 +44,24 @@ public class TR1CatItemBuilder : ItemBuilder
         CreateDefaultTests(data, TR1LevelNames.CAT);
 
         data.MeshEdits.Add(FixEgyptToppledChair(TR1Type.Architecture7, cat));
+        data.StaticMeshEdits.Add(FixEgyptPillar(cat));
+
+        var chair = cat.StaticMeshes[TR1Type.SceneryBase + 12];
+        chair.CollisionBox.MinX += 64;
+        chair.CollisionBox.MaxZ -= 64;
+        data.StaticMeshEdits.Add(new()
+        {
+            TypeID = 12,
+            Mesh = chair,
+        });
+
+        chair = cat.StaticMeshes[TR1Type.SceneryBase + 37];
+        chair.CollisionBox.MaxZ -= 48;
+        data.StaticMeshEdits.Add(new()
+        {
+            TypeID = 37,
+            Mesh = chair,
+        });
 
         return data;
     }

--- a/src/Types/TR1/Items/TR1EgyptItemBuilder.cs
+++ b/src/Types/TR1/Items/TR1EgyptItemBuilder.cs
@@ -38,6 +38,7 @@ public class TR1EgyptItemBuilder : ItemBuilder
         CreateDefaultTests(data, TR1LevelNames.EGYPT);
 
         data.MeshEdits.Add(FixEgyptToppledChair(TR1Type.Architecture7, egypt));
+        data.StaticMeshEdits.Add(FixEgyptPillar(egypt));
 
         return data;
     }

--- a/src/Types/TR1/Items/TR1KhamoonItemBuilder.cs
+++ b/src/Types/TR1/Items/TR1KhamoonItemBuilder.cs
@@ -9,11 +9,32 @@ public class TR1KhamoonItemBuilder : ItemBuilder
     public override List<InjectionData> Build()
     {
         var level = _control1.Read($"Resources/{TR1LevelNames.KHAMOON}");
+        
+
+        return new()
+        {
+            CreateItemRots(level),
+            FixMeshPositions(level),
+        };
+    }
+
+    private static InjectionData CreateItemRots(TR1Level level)
+    {
         var data = InjectionData.Create(TRGameVersion.TR1, InjectionType.ItemRotation, "khamoon_itemrots");
         CreateDefaultTests(data, TR1LevelNames.KHAMOON);
 
         data.ItemEdits.Add(SetAngle(level, 64, 16384));
 
-        return new() { data };
+        return data;
+    }
+
+    private static InjectionData FixMeshPositions(TR1Level level)
+    {
+        var data = InjectionData.Create(TRGameVersion.TR1, InjectionType.General, "khamoon_meshfixes");
+        CreateDefaultTests(data, TR1LevelNames.KHAMOON);
+
+        data.StaticMeshEdits.Add(FixEgyptPillar(level));
+
+        return data;
     }
 }

--- a/src/Types/TR1/Items/TR1ObeliskItemBuilder.cs
+++ b/src/Types/TR1/Items/TR1ObeliskItemBuilder.cs
@@ -131,5 +131,6 @@ public class TR1ObeliskItemBuilder : ItemBuilder
         }
 
         data.MeshEdits.Add(FixEgyptToppledChair(TR1Type.Furniture3, obelisk));
+        data.StaticMeshEdits.Add(FixEgyptPillar(obelisk));
     }
 }


### PR DESCRIPTION
Adjusts collision boxes on static meshes in Egypt to prevent the camera shaking when they are placed close to walls or edges and Lara walks past them.