### PR TITLE
Further texture fixes

### DIFF
--- a/src/Actions/TRFloorDataEdit.cs
+++ b/src/Actions/TRFloorDataEdit.cs
@@ -35,6 +35,7 @@ public enum FDFixType
     SectorOverwrite,
     GlideCameraFix,
     ZoneFix,
+    PortalOverwrite,
 }
 
 public abstract class FDFix
@@ -189,6 +190,21 @@ public class FDZoneFix : FDFix
         writer.Write(ZoneOverwrite.FlipOffZone.Fly);
         writer.Write(ZoneOverwrite.FlipOnZone.Ground.Values);
         writer.Write(ZoneOverwrite.FlipOnZone.Fly);
+    }
+}
+
+public class FDPortalOverwrite : FDFix
+{
+    public override FDFixType FixType => FDFixType.PortalOverwrite;
+    public short Wall { get; set; } = -1;
+    public short Sky { get; set; } = -1;
+    public short Pit { get; set; } = -1;
+
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
+    {
+        writer.Write(Wall);
+        writer.Write(Sky);
+        writer.Write(Pit);
     }
 }
 

--- a/src/Actions/TRRoomTextureEdit.cs
+++ b/src/Actions/TRRoomTextureEdit.cs
@@ -16,6 +16,7 @@ public abstract class TRRoomTextureEdit
         AddSprite,
         AddStatic3D,
         EditStatic3D,
+        SetVertexFlags,
     }
 
     public abstract TRRoomTextureFixType FixType { get; }
@@ -91,6 +92,20 @@ public class TRRoomVertexMove : TRRoomTextureEdit
         writer.Write(VertexChange.Y);
         writer.Write(VertexChange.Z);
         writer.Write(ShadeChange);
+    }
+}
+
+public class TRRoomVertxFlagChange : TRRoomTextureEdit
+{
+    public override TRRoomTextureFixType FixType => TRRoomTextureFixType.SetVertexFlags;
+    public ushort VertexIndex { get; set; }
+    public ushort Flags { get; set; }
+    public short Adder { get; set; }
+
+    protected override void SerializeImpl(TRLevelWriter writer)
+    {
+        writer.Write(VertexIndex);
+        writer.Write(Flags);
     }
 }
 

--- a/src/Actions/TRRoomTextureEdit.cs
+++ b/src/Actions/TRRoomTextureEdit.cs
@@ -99,6 +99,13 @@ public class TRRoomVertexRemap
     public short Index { get; set; }
     public ushort NewVertexIndex { get; set; }
 
+    public TRRoomVertexRemap() { }
+    public TRRoomVertexRemap(short index, ushort newIndex)
+    {
+        Index = index;
+        NewVertexIndex = newIndex;
+    }
+
     public void Serialize(TRLevelWriter writer)
     {
         writer.Write(Index);

--- a/src/Types/TR1/Textures/Ext/TR1AtlantisTextureBuilder.cs
+++ b/src/Types/TR1/Textures/Ext/TR1AtlantisTextureBuilder.cs
@@ -1,0 +1,495 @@
+﻿using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+
+namespace TRXInjectionTool.Types.TR1.Textures;
+
+public partial class TR1AtlantisTextureBuilder
+{
+    public static IEnumerable<TRRoomTextureEdit> FixCatwalks(TR1Level level)
+    {
+        foreach (var edit in CreateRoom7Edits(level, false)) yield return edit;
+        foreach (var edit in CreateRoom9Edits(level, false)) yield return edit;
+        foreach (var edit in CreateRoom7Edits(level, true)) yield return edit;
+        foreach (var edit in CreateRoom9Edits(level, true)) yield return edit;
+
+        foreach (var edit in CreateRoom13Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom14Edits(level)) yield return edit;
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom7Edits(TR1Level level, bool flip)
+    {
+        var roomIdx = (short)(flip ? 96 : 7);
+        var room = level.Rooms[roomIdx];
+
+        var sides = new ushort[] { 128, 131 };
+        var side = 0;
+
+        // Group 1: go around the sides and fill in, cycling the above textures
+        {
+            var root = 83;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 23;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[1]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[2],
+                room.Mesh.Rectangles[root].Vertices[1],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 28;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[0]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[1],
+                room.Mesh.Rectangles[root].Vertices[0],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 32;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[0]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[1],
+                room.Mesh.Rectangles[root].Vertices[0],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 90;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[0],
+                room.Mesh.Rectangles[root].Vertices[3],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 95;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[0],
+                room.Mesh.Rectangles[root].Vertices[3],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                room.Mesh.Rectangles[158].Vertices[3],
+            });
+
+            root = 46;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[0]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[1],
+                room.Mesh.Rectangles[root].Vertices[0],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 50;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[0]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[1],
+                room.Mesh.Rectangles[root].Vertices[0],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 53;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[0]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[1],
+                room.Mesh.Rectangles[root].Vertices[0],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 103;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[0]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[1],
+                room.Mesh.Rectangles[root].Vertices[0],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[0],
+                room.Mesh.Rectangles[root].Vertices[3],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            foreach (var root2 in new[] { 168, 212, 252, 292, 340 })
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root2].Vertices[0]]);
+                yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+                {
+                    room.Mesh.Rectangles[root2].Vertices[1],
+                    room.Mesh.Rectangles[root2].Vertices[0],
+                    (ushort)(room.Mesh.Vertices.Count - 1),
+                    (ushort)(room.Mesh.Vertices.Count - 2),
+                });
+            }
+
+            root = 396;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[1]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[2],
+                room.Mesh.Rectangles[root].Vertices[1],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            foreach (var root2 in new[] { 437, 435 })
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root2].Vertices[3]]);
+                yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+                {
+                    room.Mesh.Rectangles[root2].Vertices[0],
+                    room.Mesh.Rectangles[root2].Vertices[3],
+                    (ushort)(room.Mesh.Vertices.Count - 1),
+                    (ushort)(room.Mesh.Vertices.Count - 2),
+                });
+            }
+
+            root = 433;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[0]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[1],
+                room.Mesh.Rectangles[root].Vertices[0],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 383;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[0],
+                room.Mesh.Rectangles[root].Vertices[3],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 376;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[1]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[2],
+                room.Mesh.Rectangles[root].Vertices[1],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                room.Mesh.Rectangles[378].Vertices[2],
+            });
+
+            foreach (var root2 in new[] { 424, 422, 419 })
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root2].Vertices[0]]);
+                yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+                {
+                    room.Mesh.Rectangles[root2].Vertices[1],
+                    room.Mesh.Rectangles[root2].Vertices[0],
+                    (ushort)(room.Mesh.Vertices.Count - 1),
+                    (ushort)(room.Mesh.Vertices.Count - 2),
+                });
+            }
+
+            root = 417;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 415;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[1]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[2],
+                room.Mesh.Rectangles[root].Vertices[1],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            foreach (var root2 in new[] { 413, 411 })
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root2].Vertices[0]]);
+                yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+                {
+                    room.Mesh.Rectangles[root2].Vertices[1],
+                    room.Mesh.Rectangles[root2].Vertices[0],
+                    (ushort)(room.Mesh.Vertices.Count - 1),
+                    (ushort)(room.Mesh.Vertices.Count - 2),
+                });
+            }
+
+            root = 350;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[0],
+                room.Mesh.Rectangles[root].Vertices[3],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            root = 348;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            foreach (var root2 in new[] { 296, 256, 216, 172, 110 })
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root2].Vertices[2]]);
+                yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+                {
+                    room.Mesh.Rectangles[root2].Vertices[3],
+                    room.Mesh.Rectangles[root2].Vertices[2],
+                    (ushort)(room.Mesh.Vertices.Count - 1),
+                    (ushort)(room.Mesh.Vertices.Count - 2),
+                });
+            }
+
+            foreach (var root2 in new[] { 70, 73 })
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root2].Vertices[0]]);
+                yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+                {
+                    room.Mesh.Rectangles[root2].Vertices[1],
+                    room.Mesh.Rectangles[root2].Vertices[0],
+                    (ushort)(room.Mesh.Vertices.Count - 1),
+                    (ushort)(room.Mesh.Vertices.Count - 2),
+                });
+            }
+
+            root = 73;
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[0],
+                room.Mesh.Rectangles[root].Vertices[3],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            foreach (var root2 in new[] { 10, 14, 18 })
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root2].Vertices[0]]);
+                yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+                {
+                    room.Mesh.Rectangles[root2].Vertices[1],
+                    room.Mesh.Rectangles[root2].Vertices[0],
+                    (ushort)(room.Mesh.Vertices.Count - 1),
+                    (ushort)(room.Mesh.Vertices.Count - 2),
+                });
+            }
+        }
+
+        // Group 2: straightforward face inversion for the outsides
+        foreach (var root in new[] {
+            131, 136, 189, 193, 235, 275, 315, 316, 366, 362, 358, 309, 307, 266, 226, 183, 182,
+            126, 124, 128, 147, 158, 203, 206, 246, 286, 331, 332, 324, 322, 277, 237, 196, 195,
+        })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        var floors = new ushort[] { 300, 260 };
+        var floor = 0;
+        foreach (var root in new[] {
+            305, 302, 300, 262, 260, 222, 220, 178, 176, 114, 116, 120, 75, 77, 79, 81, 84, 86, 88,
+            141, 138, 133, 191, 233, 273, 318, 320, 313, 373, 370, 367, 364, 360, 356, 353, 97, 99,
+            101, 155, 159, 162, 165, 204, 207, 209, 244, 247, 249, 284, 287, 289, 329, 333, 335, 337,
+            393, 390, 387,
+        })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 7, floors[floor++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom9Edits(TR1Level level, bool flip)
+    {
+        var roomIdx = (short)(flip ? 95 : 9);
+        var room = level.Rooms[roomIdx];
+
+        var floors = new ushort[] { 300, 260 };
+        var floor = 0;
+        foreach (var root in new[] {
+            280, 278, 276, 274, 272, 270, 268, 234, 232, 230, 199, 201, 168, 166, 136, 138, 102, 104,
+            106, 62, 64, 66, 68, 71, 73, 75, 115, 113, 111, 145, 176, 208, 239, 241, 243, 288, 290, 292,
+            248, 250, 252, 254, 215, 217, 219, 185, 187, 189, 152, 154, 156, 120, 122, 124, 126, 84, 86, 88,
+        })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 7, floors[floor++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom13Edits(TR1Level level)
+    {
+        const short roomIdx = 13;
+        var room = level.Rooms[roomIdx];
+
+        var sides = new ushort[] { 128, 131 };
+        int side = 0;
+
+        // Group 1: go around the sides and fill in, cycling the above textures
+        foreach (var root in new[] { 27, 3 })
+        {
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 27
+                    ? room.Mesh.Rectangles[51].Vertices[2]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        {
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[0].Vertices[1],
+                room.Mesh.Rectangles[0].Vertices[2],
+                room.Mesh.Rectangles[6].Vertices[3],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+            });
+
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[46].Vertices[2],
+                room.Mesh.Rectangles[46].Vertices[3],
+                room.Mesh.Rectangles[65].Vertices[2],
+                room.Mesh.Rectangles[48].Vertices[3],
+            });
+        }
+
+        // Group 2: straightforward face inversion for the outsides
+        foreach (var root in new[] { 48, 45, 41, 42, 61, 63, 65, 50, 54, 56, 36, 34, 31, 8 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 7, sides[side++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        var floors = new ushort[] { 300, 260 };
+        var floor = 0;
+        foreach (var root in new[] { 0, 25, 29, 32, 39, 43, 46 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 7, floors[floor++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom14Edits(TR1Level level)
+    {
+        const short roomIdx = 14;
+        var room = level.Rooms[roomIdx];
+
+        var floors = new ushort[] { 300, 260 };
+        var floor = 0;
+        foreach (var root in new[] { 1, 43, 48, 50, 55, 57, 59 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 7, floors[floor++ % 2], TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+}

--- a/src/Types/TR1/Textures/TR1AtlantisTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1AtlantisTextureBuilder.cs
@@ -5,7 +5,7 @@ using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR1.Textures;
 
-public class TR1AtlantisTextureBuilder : TextureBuilder
+public partial class TR1AtlantisTextureBuilder : TextureBuilder
 {
     public override List<InjectionData> Build()
     {
@@ -17,6 +17,7 @@ public class TR1AtlantisTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(atlantis));
         data.RoomEdits.AddRange(CreateRotations());
         data.RoomEdits.AddRange(CreateShifts(atlantis));
+        data.RoomEdits.AddRange(FixCatwalks(atlantis));
         FixPlatformDoorArea(data, atlantis);
         FixPassport(atlantis, data);
 
@@ -282,6 +283,25 @@ public class TR1AtlantisTextureBuilder : TextureBuilder
             Reface(atlantis, 88, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 8, 10),
             Reface(atlantis, 90, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 8, 6),
             Reface(atlantis, 62, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 8, 7),
+
+            Reface(atlantis, 7, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 101),
+            Reface(atlantis, 7, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 393),
+            Reface(atlantis, 9, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 102),
+            Reface(atlantis, 9, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 68),
+            Reface(atlantis, 9, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 2, 77),
+            Reface(atlantis, 9, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 2, 82),
+            Reface(atlantis, 9, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 274),
+            Reface(atlantis, 9, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 2, 282),
+            Reface(atlantis, 9, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 2, 286),
+            Reface(atlantis, 95, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 68),
+            Reface(atlantis, 95, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 2, 77),
+            Reface(atlantis, 95, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 2, 82),
+            Reface(atlantis, 95, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 274),
+            Reface(atlantis, 95, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 102),
+            Reface(atlantis, 95, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 2, 282),
+            Reface(atlantis, 95, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 2, 286),
+            Reface(atlantis, 96, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 101),
+            Reface(atlantis, 96, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 34, 393),
         };
     }
 

--- a/src/Types/TR1/Textures/TR1CatTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1CatTextureBuilder.cs
@@ -136,6 +136,8 @@ public class TR1CatTextureBuilder : TextureBuilder
             cat.Rooms[2].Mesh.Rectangles[128], Color.FromArgb(188, 140, 64));
         FixTransparentPixels(cat, data,
             cat.Rooms[7].Mesh.Rectangles[19], Color.FromArgb(188, 140, 64));
+        FixTransparentPixels(cat, data,
+            cat.Rooms[95].Mesh.Rectangles[7], Color.FromArgb(252, 228, 140));
     }
 
     private InjectionData CreateBaseData()

--- a/src/Types/TR1/Textures/TR1FollyTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1FollyTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using System.Drawing;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -17,7 +18,7 @@ public class TR1FollyTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRefacings(folly));
         data.RoomEdits.AddRange(CreateRotations());
         data.RoomEdits.AddRange(CreateShifts(folly));
-
+        FixTransparentTextures(folly, data);
         FixPassport(folly, data);
 
         return new() { data };
@@ -124,5 +125,11 @@ public class TR1FollyTextureBuilder : TextureBuilder
                 }
             },
         };
+    }
+
+    private static void FixTransparentTextures(TR1Level level, InjectionData data)
+    {
+        FixTransparentPixels(level, data,
+            level.Rooms[25].Mesh.Rectangles[12], Color.FromArgb(112, 96, 72));
     }
 }

--- a/src/Types/TR1/Textures/TR1StrongholdTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1StrongholdTextureBuilder.cs
@@ -93,6 +93,7 @@ public class TR1StrongholdTextureBuilder : TextureBuilder
         return new()
         {
             Rotate(6, TRMeshFaceType.TexturedQuad, 462, 3),
+            Rotate(27, TRMeshFaceType.TexturedTriangle, 3, 1),
         };
     }
 

--- a/src/Types/TR1/Textures/TR1VilcabambaTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1VilcabambaTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRImageControl.Packing;
+﻿using System.Drawing;
+using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
@@ -212,14 +213,16 @@ public class TR1VilcabambaTextureBuilder : TextureBuilder
                 f.Texture = (ushort)level.ObjectTextures.IndexOf(originalInfos[f.Texture]);
             });
 
-        var p = new List<ushort> {11,15,17,18 };
-        var f = statue.Mesh.TexturedRectangles.FindIndex(v => v.Vertices.All(p.Contains));
         statue.Mesh.TexturedRectangles.Add(new()
         {
             Type = TRFaceType.Rectangle,
             Texture = statue.Mesh.TexturedRectangles[9].Texture,
             Vertices = new() { 20, 23, 22, 21 }
         });
+
+        var img = GetImage(statue.Mesh.TexturedRectangles[13].Texture, level);
+        img.Write((c, x, y) => c.A == 0 ? Color.FromArgb(52, 52, 40) : c);
+        ImportImage(statue.Mesh.TexturedRectangles[13].Texture, img, level);
 
         var data = InjectionData.Create(level, InjectionType.TextureFix, ID);
         CreateDefaultTests(data, TR1LevelNames.VILCABAMBA);

--- a/src/Types/TR2/FD/TR2CatacombsFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2CatacombsFDBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using TRLevelControl;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -15,6 +16,7 @@ public class TR2CatacombsFDBuilder : FDBuilder
         CreateDefaultTests(data, TR2LevelNames.COT);
         data.FloorEdits.AddRange(FixMaskRoomFlipmap(catacombs));
         data.FloorEdits.AddRange(FixStartMusicTriggers(catacombs));
+        FixYetiRoom(catacombs, data);
 
         return new() { data };
     }
@@ -73,5 +75,39 @@ public class TR2CatacombsFDBuilder : FDBuilder
             ConvertTrigger(catacombs, 74, 2, 1, FDTrigType.Pad),
             ConvertTrigger(catacombs, 74, 2, 2, FDTrigType.Pad),
         };
+    }
+
+    private static void FixYetiRoom(TR2Level level, InjectionData data)
+    {
+        data.FloorEdits.AddRange(new[] { 0, 11 }.Select(z =>
+        {
+            var sector = TRRoomSectorExt.CloneFrom(level.Rooms[41].GetSector(7, z, TRUnit.Sector));
+            sector.FDIndex = 0;
+            sector.Ceiling = TRConsts.NoHeight;
+            sector.Floor = TRConsts.NoHeight;
+            return new TRFloorDataEdit
+            {
+                RoomIndex = 41,
+                X = 7,
+                Z = (ushort)z,
+                Fixes = new()
+                {
+                    new FDSectorOverwrite { Sector = sector },
+                    new FDPortalOverwrite(),
+                }
+            };
+        }));
+
+        var mesh = level.Rooms[41].Mesh;
+        data.RoomEdits.Add(TextureBuilder.CreateFace(41, 50, 96, TRMeshFaceType.TexturedQuad, new[]
+        {
+            mesh.Rectangles[115].Vertices[1], mesh.Rectangles[135].Vertices[0],
+            mesh.Rectangles[134].Vertices[3], mesh.Rectangles[115].Vertices[2],
+        }));
+        data.RoomEdits.Add(TextureBuilder.CreateFace(41, 50, 96, TRMeshFaceType.TexturedQuad, new[]
+        {
+            mesh.Rectangles[117].Vertices[1], mesh.Rectangles[96].Vertices[0],
+            mesh.Rectangles[96].Vertices[3], mesh.Rectangles[116].Vertices[2],
+        }));
     }
 }

--- a/src/Types/TR2/Textures/Ext/TR2Cut3TextureBuilder.cs
+++ b/src/Types/TR2/Textures/Ext/TR2Cut3TextureBuilder.cs
@@ -1,0 +1,66 @@
+﻿using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+
+namespace TRXInjectionTool.Types.TR2.Textures;
+
+public partial class TR2Cut3TextureBuilder
+{
+    public static IEnumerable<TRRoomTextureEdit> FixCatwalks(TR2Level level,
+        short topRoomIdx = 7, short bottomRoomIdx = 8)
+    {
+        foreach (var edit in CreateRoom7Edits(level, topRoomIdx)) yield return edit;
+        foreach (var edit in CreateRoom8Edits(level, bottomRoomIdx)) yield return edit;
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom7Edits(TR2Level level, short roomIdx)
+    {
+        var room = level.Rooms[roomIdx];
+
+        foreach (var root in new[] { 30, 33, 36, 61, 83, 105, 127, 154, 169, 168, 166, 165, 163 })
+        {
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, roomIdx, 31, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[root == 33 ? 1 : 3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 30
+                    ? room.Mesh.Rectangles[31].Vertices[3]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        foreach (var root in new[] { 31, 55, 77, 99, 121, 146, 143, 138, 139 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, roomIdx, 31, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        foreach (var root in new[] { 27, 33, 57, 53, 75, 79, 97, 101, 123, 119, 151, 148, 144, 141, 136 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, roomIdx, 33, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom8Edits(TR2Level level, short roomIdx)
+    {
+        var room = level.Rooms[roomIdx];
+
+        foreach (var root in new[] { 25, 29, 48, 46, 61, 63, 76, 78, 91, 93, 114, 112, 110, 108, 105 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, roomIdx, 29, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+}

--- a/src/Types/TR2/Textures/Ext/TR2DivingTextureBuilder.cs
+++ b/src/Types/TR2/Textures/Ext/TR2DivingTextureBuilder.cs
@@ -1,0 +1,117 @@
+﻿using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+
+namespace TRXInjectionTool.Types.TR2.Textures;
+
+public partial class TR2DivingTextureBuilder
+{
+    private static IEnumerable<TRRoomTextureEdit> FixCatwalks(TR2Level level)
+    {
+        foreach (var edit in CreateRoom52Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom54Edits(level)) yield return edit;
+        foreach (var edit in TR2Cut3TextureBuilder.FixCatwalks(level, 76, 77)) yield return edit;
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom52Edits(TR2Level level)
+    {
+        const short roomIdx = 52;
+        var room = level.Rooms[roomIdx];
+
+        foreach (var root in new[] { 10, 28, 40, 51, 61, 71, 84, 94, 104, 114, 124, 134 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 52, 10, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom54Edits(TR2Level level)
+    {
+        const short roomIdx = 54;
+        var room = level.Rooms[roomIdx];
+
+        {
+            yield return CreateFace(roomIdx, 54, 7, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[6].Vertices[2],
+                room.Mesh.Rectangles[6].Vertices[1],
+                room.Mesh.Rectangles[9].Vertices[2],
+                room.Mesh.Rectangles[7].Vertices[3],
+            });
+            yield return CreateFace(roomIdx, 54, 7, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[99].Vertices[3],
+                room.Mesh.Rectangles[99].Vertices[0],
+                room.Mesh.Rectangles[100].Vertices[2],
+                room.Mesh.Rectangles[101].Vertices[3],
+            });
+            yield return CreateFace(roomIdx, 54, 7, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[51].Vertices[3],
+                room.Mesh.Rectangles[51].Vertices[2],
+                room.Mesh.Rectangles[36].Vertices[2],
+                room.Mesh.Rectangles[76].Vertices[3],
+            });
+        }
+
+        foreach (var root in new[] { 7, 16, 21, 26, 31, 36, 76, 85, 90, 95, 100, 9, 17, 22, 27, 32, 37, 60, 78, 86, 91, 96, 101 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 54, 7, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        foreach (var root in new[] { 5, 15, 20, 25, 30, 35, 55, 74, 84, 89, 94, 99 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 54, 5, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        {
+            // Fix stretching
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[44].Vertices[1]]);
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[44].Vertices[0]]);
+
+            yield return CreateQuadShift(roomIdx, 68, new()
+            {
+                new(0, (ushort)(room.Mesh.Vertices.Count - 2)),
+                new(1, room.Mesh.Rectangles[70].Vertices[0]),
+            });
+            yield return CreateQuadShift(roomIdx, 44, new()
+            {
+                new(0, (ushort)(room.Mesh.Vertices.Count - 1)),
+                new(1, (ushort)(room.Mesh.Vertices.Count - 2)),
+            });
+            yield return CreateQuadShift(roomIdx, 42, new()
+            {
+                new(0, room.Mesh.Rectangles[48].Vertices[1]),
+                new(1, (ushort)(room.Mesh.Vertices.Count - 1)),
+            });
+
+            yield return CreateFace(roomIdx, 54, 7, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[68].Vertices[0], room.Mesh.Rectangles[68].Vertices[1],
+                room.Mesh.Rectangles[70].Vertices[0], (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+            yield return CreateFace(roomIdx, 54, 7, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[44].Vertices[0], room.Mesh.Rectangles[44].Vertices[1],
+                (ushort)(room.Mesh.Vertices.Count - 2), (ushort)(room.Mesh.Vertices.Count - 1),
+            });
+            yield return CreateFace(roomIdx, 54, 7, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[42].Vertices[0], room.Mesh.Rectangles[42].Vertices[1],
+                (ushort)(room.Mesh.Vertices.Count - 1), room.Mesh.Rectangles[48].Vertices[1],
+            });
+        }
+    }
+}

--- a/src/Types/TR2/Textures/Ext/TR2RigTextureBuilder.cs
+++ b/src/Types/TR2/Textures/Ext/TR2RigTextureBuilder.cs
@@ -1,0 +1,685 @@
+﻿using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+using TRXInjectionTool.Util;
+
+namespace TRXInjectionTool.Types.TR2.Textures;
+
+public partial class TR2RigTextureBuilder
+{
+    private static IEnumerable<TRRoomTextureEdit> FixCatwalks(TR2Level level)
+    {
+        foreach (var edit in CreateRoom32Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom33Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom40Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom44Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom46Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom47Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom48Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom49Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom63Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom98Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom99Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom100Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom101Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom102Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom107Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom108Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom109Edits(level)) yield return edit;
+        foreach (var edit in CreateRoom110Edits(level)) yield return edit;
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom32Edits(TR2Level level)
+    {
+        const short roomIdx = 32;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 33
+        foreach (var root in new[] { 4, 12, 24, 35, 47, 59, 72, 14, 26, 49, 61, 75, 70 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 33, 114, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom33Edits(TR2Level level)
+    {
+        const short roomIdx = 33;
+        var room = level.Rooms[roomIdx];
+
+        // Group 1: needs vertex creation
+        foreach (var root in new[] { 19, 22, 36, 37, 52 })
+        {
+            var vtx = room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]];
+            yield return CreateVertex(roomIdx, room, vtx);
+            yield return CreateFace(roomIdx, 33, 20, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 19
+                    ? room.Mesh.Rectangles[20].Vertices[3]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        // Group 2: also needs vertex creation, but gap in floor from above group
+        foreach (var root in new[] { 91, 107, 125, 134, 133, 131 })
+        {
+            var vtx = room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]];
+            yield return CreateVertex(roomIdx, room, vtx);
+            yield return CreateFace(roomIdx, 33, 20, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 91
+                    ? room.Mesh.Rectangles[89].Vertices[3]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        // Group 3: straightforward face inversion for the sides
+        foreach (var root in new[] { 20, 32, 48, 66, 69, 71, 85, 89, 101, 116, 117 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 33, 20, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 4: as above but for the floor
+        foreach (var root in new[] { 114, 119, 123, 104, 83, 87, 64, 46, 50, 30, 34, 17 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 33, 114, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Special case for below the wall beside the pushblock
+        yield return CreateFace(roomIdx, 33, 103, TRMeshFaceType.TexturedQuad, new[]
+        {
+            room.Mesh.Rectangles[106].Vertices[3],
+            room.Mesh.Rectangles[106].Vertices[2],
+            room.Mesh.Rectangles[103].Vertices[3],
+            room.Mesh.Rectangles[103].Vertices[2],
+        });
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom40Edits(TR2Level level)
+    {
+        const short roomIdx = 40;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 101
+        foreach (var root in new[] { 75, 63, 61 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        foreach (var root in new[] { 59 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 40, 59, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom44Edits(TR2Level level)
+    {
+        const short roomIdx = 44;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 101
+        foreach (var root in new[] { 68 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 44, 68, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom46Edits(TR2Level level)
+    {
+        const short roomIdx = 46;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 48
+        foreach (var root in new[] { 1, 6, 11, 16, 21, 26, 31, 51, 62, 66, 73 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 46, 1, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom47Edits(TR2Level level)
+    {
+        const short roomIdx = 47;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 49
+        foreach (var root in new[] { 57, 59, 61, 63, 65, 67, 69, 71, 73 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 46, 1, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom48Edits(TR2Level level)
+    {
+        const short roomIdx = 48;
+        var room = level.Rooms[roomIdx];
+
+        // Group 1: standalones are awkward - last in this list must be physically connected to first in concat list
+        var standalones = new[] { 39, 59, 100, 116, 3 };
+        foreach (var root in standalones.Concat(new[] { 7, 11, 15, 19, 24, 29 }))
+        {
+            if (standalones.Contains(root))
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            }
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        // Group 2: straightforward face inversion for the sides
+        foreach (var root in new[] { 41, 45, 47, 49, 52, 56, 75, 94, 34, 79, 96, 98, 85, 83 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        foreach (var root in new[] { 0, 4, 8, 12, 16, 21, 26, 54, 73, 81, 92 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 15, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom49Edits(TR2Level level)
+    {
+        const short roomIdx = 49;
+        var room = level.Rooms[roomIdx];
+
+        // Group 1: vertex creations
+        var breakers = new[] { 94, 110, 100, 68 };
+        foreach (var root in new[] { 94, 110, 108, 106, 104, 102, 100, 98, 96, 68 })
+        {
+            if (breakers.Contains(root))
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            }
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+
+            if (root == 100)
+            {
+                yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+                {
+                    room.Mesh.Rectangles[75].Vertices[3],
+                    room.Mesh.Rectangles[75].Vertices[0],
+                    (ushort)(room.Mesh.Vertices.Count - 2),
+                    (ushort)(room.Mesh.Vertices.Count - 3),
+                });
+            }
+        }
+
+        // Group 2: straightforward face inversion for the sides
+        foreach (var root in new[] { 91, 88, 84, 80, 77, 74, 71 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        foreach (var root in new[] { 66, 69, 72, 75, 78, 82, 86, 89, 92 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 15, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom63Edits(TR2Level level)
+    {
+        const short roomIdx = 63;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 98
+        {
+            var face = room.Mesh.Rectangles[56];
+            yield return CreateFace(roomIdx, 46, 1, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom98Edits(TR2Level level)
+    {
+        const short roomIdx = 98;
+        var room = level.Rooms[roomIdx];
+
+        // Group 1: vertex creations
+        {
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[76].Vertices[3]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[76].Vertices[3],
+                room.Mesh.Rectangles[76].Vertices[2],
+                room.Mesh.Rectangles[53].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+            });
+        }
+
+        // Group 2: straightforward face inversion for the sides
+        foreach (var root in new[] { 13, 52, 53 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        {
+            var face = room.Mesh.Rectangles[50];
+            yield return CreateFace(roomIdx, 100, 15, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom99Edits(TR2Level level)
+    {
+        const short roomIdx = 99;
+        var room = level.Rooms[roomIdx];
+
+        // Group 1: vertex creations
+        var breakers = new[] { 17, 110, 156 };
+        foreach (var root in new[] { 15, 17, 110, 125, 140, 158, 156 })
+        {
+            if (breakers.Contains(root))
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            }
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 15
+                    ? room.Mesh.Rectangles[32].Vertices[3]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        {
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[29].Vertices[3],
+                room.Mesh.Rectangles[29].Vertices[2],
+                room.Mesh.Rectangles[33].Vertices[2],
+                room.Mesh.Rectangles[30].Vertices[3],
+            });
+        }
+
+        // Group 2: straightforward face inversion for the sides
+        foreach (var root in new[] { 30, 47, 33, 32, 106, 108, 123, 138 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        foreach (var root in new[] { 13, 27, 104, 121, 136, 154 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 15, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom100Edits(TR2Level level)
+    {
+        const short roomIdx = 100;
+        var room = level.Rooms[roomIdx];
+
+        // Group 1: needs vertex creation
+        foreach (var root in new[] { 18, 23 })
+        {
+            var vtx = room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]];
+            yield return CreateVertex(roomIdx, room, vtx);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 18
+                    ? room.Mesh.Rectangles[19].Vertices[3]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        // Group 2: straightforward face inversion for the sides
+        foreach (var root in new[] { 19, 28, 37, 45, 47, 77, 80 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        foreach (var root in new[] { 15, 20 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 15, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom101Edits(TR2Level level)
+    {
+        const short roomIdx = 101;
+        var room = level.Rooms[roomIdx];
+
+        // Group 1: needs vertex creation
+        foreach (var root in new[] { 25, 3 })
+        {
+            var vtx = room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]];
+            yield return CreateVertex(roomIdx, room, vtx);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 25
+                    ? room.Mesh.Rectangles[44].Vertices[3]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        foreach (var root in new[] { 31, 10, 13 })
+        {
+            if (root == 13)
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            }
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 31
+                    ? room.Mesh.Rectangles[28].Vertices[3]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        foreach (var root in new[] { 63, 78, 100, 122, 177 })
+        {
+            if (root == 177)
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            }
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                root == 63
+                    ? room.Mesh.Rectangles[60].Vertices[3]
+                    : (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        // Group 2: straightforward face inversion for the sides
+        foreach (var root in new[] { 44, 49, 51, 53, 55, 37, 16, 28, 5, 60, 61, 76, 99, 121, 134, 168, 166, 162, 163, 175, 174 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        foreach (var root in new[] { 0, 22, 26, 29, 32, 34, 8, 11, 58, 74, 96, 118, 164, 160 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 15, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom102Edits(TR2Level level)
+    {
+        const short roomIdx = 102;
+        var room = level.Rooms[roomIdx];
+
+        // Group 1: needs vertex creation
+        {
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[11].Vertices[2]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[11].Vertices[3],
+                room.Mesh.Rectangles[11].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                room.Mesh.Rectangles[28].Vertices[3]
+            });
+        }
+
+        {
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[5].Vertices[2]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[5].Vertices[3],
+                room.Mesh.Rectangles[5].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                room.Mesh.Rectangles[23].Vertices[3]
+            });
+        }
+
+        foreach (var root in new[] { 8, 26 })
+        {
+            if (root == 8)
+            {
+                yield return CreateVertex(roomIdx, room,
+                    room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[3]]);
+            }
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[root].Vertices[2]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[root].Vertices[3],
+                room.Mesh.Rectangles[root].Vertices[2],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                (ushort)(room.Mesh.Vertices.Count - 2),
+            });
+        }
+
+        {
+            yield return CreateVertex(roomIdx, room,
+                room.Mesh.Vertices[room.Mesh.Rectangles[59].Vertices[1]]);
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[59].Vertices[2],
+                room.Mesh.Rectangles[59].Vertices[1],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+                room.Mesh.Rectangles[62].Vertices[2],
+            });
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                room.Mesh.Rectangles[56].Vertices[2],
+                room.Mesh.Rectangles[56].Vertices[1],
+                room.Mesh.Rectangles[58].Vertices[3],
+                (ushort)(room.Mesh.Vertices.Count - 1),
+            });
+        }
+
+
+        // Group 2: straightforward face inversion for the sides
+        foreach (var root in new[] { 45, 23, 40, 13, 28, 54 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 51, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        // Group 3: as above but for the floor
+        foreach (var root in new[] { 38, 41, 21, 24, 3, 6, 9 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 100, 15, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom107Edits(TR2Level level)
+    {
+        const short roomIdx = 107;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 99
+        foreach (var root in new[] { 16, 34, 92, 107, 122, 144 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 107, 16, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom108Edits(TR2Level level)
+    {
+        const short roomIdx = 108;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 100
+        foreach (var root in new[] { 16, 21 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 108, 16, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom109Edits(TR2Level level)
+    {
+        const short roomIdx = 109;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 101
+        foreach (var root in new[] { 1, 9, 12, 23, 28, 30, 32, 35, 56, 71, 86, 101, 145, 148 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            if (root == 101)
+            {
+                yield return Rotate(roomIdx, TRMeshFaceType.TexturedQuad, 101, 3);
+                face.Rotate(3);
+            }
+            yield return CreateFace(roomIdx, 108, 16, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+    }
+
+    private static IEnumerable<TRRoomTextureEdit> CreateRoom110Edits(TR2Level level)
+    {
+        const short roomIdx = 110;
+        var room = level.Rooms[roomIdx];
+
+        // Face inversion when viewed from room 102
+        foreach (var root in new[] { 4, 6, 10, 20, 22, 35, 37 })
+        {
+            var face = room.Mesh.Rectangles[root];
+            yield return CreateFace(roomIdx, 108, 16, TRMeshFaceType.TexturedQuad, new[]
+            {
+                face.Vertices[1], face.Vertices[0], face.Vertices[3], face.Vertices[2]
+            });
+        }
+
+        yield return Reface(level, roomIdx, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1667, 52);
+        yield return Reface(level, roomIdx, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1667, 54);
+    }
+}

--- a/src/Types/TR2/Textures/TR2BartoliTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2BartoliTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRImageControl;
+﻿using System.Drawing;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
@@ -21,7 +22,7 @@ public class TR2BartoliTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
         data.MeshEdits.Add(
             FixStaticMeshPosition(bartoli.StaticMeshes, TR2Type.Architecture4, new() { Z = 27 }));
-
+        FixTransparentTextures(bartoli, data);
         FixPassport(bartoli, data);
 
         return new() { data };
@@ -164,5 +165,11 @@ public class TR2BartoliTextureBuilder : TextureBuilder
         CreateDefaultTests(data, TR2LevelNames.BARTOLI);
 
         return data;
+    }
+
+    private static void FixTransparentTextures(TR2Level level, InjectionData data)
+    {
+        FixTransparentPixels(level, data,
+            level.Rooms[107].Mesh.Rectangles[60], Color.FromArgb(139, 131, 41));
     }
 }

--- a/src/Types/TR2/Textures/TR2BartoliTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2BartoliTextureBuilder.cs
@@ -40,41 +40,89 @@ public class TR2BartoliTextureBuilder : TextureBuilder
             Reface(level, 56, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1623, 14),
             Reface(level, 56, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1623, 33),
             Reface(level, 56, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1643, 34),
+            Reface(level, 121, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1589, 78),
+            Reface(level, 121, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1589, 87),
+            Reface(level, 121, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1589, 98),
+            Reface(level, 121, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1589, 107),
+            Reface(level, 121, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1588, 114),
+            Reface(level, 121, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1588, 116),
+            Reface(level, 121, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1588, 117),
             Reface(level, 127, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1744, 57),
             Reface(level, 131, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1735, 7),
             Reface(level, 145, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1579, 40),
         };
     }
 
-    private static List<TRRoomVertexMove> CreateVertexShifts(TR2Level level)
+    private static List<TRRoomTextureEdit> CreateVertexShifts(TR2Level level)
     {
-        var result = new List<TRRoomVertexMove>
+        var vert = level.Rooms[121].Mesh.Vertices[level.Rooms[121].Mesh.Rectangles[13].Vertices[2]];
+        vert.Vertex.Y += 256;
+
+        var result = new List<TRRoomTextureEdit>
         {
-            new()
+            new TRRoomVertexCreate
+            {
+                RoomIndex = 121,
+                Vertex = new()
+                {
+                    Lighting = vert.Lighting,
+                    Vertex = vert.Vertex,
+                },
+            },
+            new TRRoomTextureMove
+            {
+                RoomIndex = 121,
+                FaceType = TRMeshFaceType.TexturedQuad,
+                TargetIndex = 12,
+                VertexRemap = new()
+                {
+                    new()
+                    {
+                        Index = 1,
+                        NewVertexIndex = (ushort)level.Rooms[121].Mesh.Vertices.Count,
+                    },
+                }
+            },
+            new TRRoomTextureMove
+            {
+                RoomIndex = 121,
+                FaceType = TRMeshFaceType.TexturedQuad,
+                TargetIndex = 13,
+                VertexRemap = new()
+                {
+                    new()
+                    {
+                        Index = 2,
+                        NewVertexIndex = (ushort)level.Rooms[121].Mesh.Vertices.Count,
+                    },
+                }
+            },
+
+            new TRRoomVertexMove
             {
                 RoomIndex = 17,
                 VertexIndex = level.Rooms[17].Mesh.Rectangles[4].Vertices[2],
                 VertexChange = new() { Y = 1024 },
             },
-            new()
+            new TRRoomVertexMove
             {
                 RoomIndex = 17,
                 VertexIndex = level.Rooms[17].Mesh.Rectangles[4].Vertices[3],
                 VertexChange = new() { Y = 1024 },
             },
-            new()
+            new TRRoomVertexMove
             {
                 RoomIndex = 17,
                 VertexIndex = level.Rooms[17].Mesh.Rectangles[5].Vertices[2],
                 VertexChange = new() { Y = -768 },
             },
-            new()
+            new TRRoomVertexMove
             {
                 RoomIndex = 17,
                 VertexIndex = level.Rooms[17].Mesh.Rectangles[5].Vertices[3],
                 VertexChange = new() { Y = -768 },
             },
-            new()
+            new TRRoomVertexMove
             {
                 RoomIndex = 108,
                 VertexIndex = level.Rooms[108].Mesh.Rectangles[9].Vertices[2],
@@ -90,6 +138,16 @@ public class TR2BartoliTextureBuilder : TextureBuilder
                 VertexChange = new() { Y = 256 },
             });
         result.AddRange(columnShifts);
+
+        columnShifts = new[] { 13, 10, 7, 2 }
+            .Select(f => new TRRoomVertexMove
+            {
+                RoomIndex = 121,
+                VertexIndex = level.Rooms[121].Mesh.Rectangles[f].Vertices[3],
+                VertexChange = new() { Y = 256 },
+            });
+        result.AddRange(columnShifts);
+
         return result;
     }
 
@@ -100,6 +158,9 @@ public class TR2BartoliTextureBuilder : TextureBuilder
             Rotate(46, TRMeshFaceType.TexturedQuad, 48, 3),
             Rotate(73, TRMeshFaceType.TexturedQuad, 119, 3),
             Rotate(143, TRMeshFaceType.TexturedQuad, 116, 3),
+            Rotate(121, TRMeshFaceType.TexturedQuad, 114, 2),
+            Rotate(121, TRMeshFaceType.TexturedQuad, 116, 2),
+            Rotate(121, TRMeshFaceType.TexturedQuad, 117, 2),
             Rotate(127, TRMeshFaceType.TexturedQuad, 57, 3),
             Rotate(131, TRMeshFaceType.TexturedQuad, 7, 2),
             Rotate(146, TRMeshFaceType.TexturedQuad, 52, 3),

--- a/src/Types/TR2/Textures/TR2Cut3TextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2Cut3TextureBuilder.cs
@@ -5,7 +5,7 @@ using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR2.Textures;
 
-public class TR2Cut3TextureBuilder : TextureBuilder
+public partial class TR2Cut3TextureBuilder : TextureBuilder
 {
     public override string ID => "cut3_textures";
 
@@ -17,6 +17,7 @@ public class TR2Cut3TextureBuilder : TextureBuilder
 
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
+        data.RoomEdits.AddRange(FixCatwalks(level));
 
         return new() { data };
     }

--- a/src/Types/TR2/Textures/TR2DivingTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2DivingTextureBuilder.cs
@@ -7,7 +7,7 @@ using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR2.Textures;
 
-public class TR2DivingTextureBuilder : TextureBuilder
+public partial class TR2DivingTextureBuilder : TextureBuilder
 {
     public override string ID => "diving_textures";
 
@@ -18,6 +18,7 @@ public class TR2DivingTextureBuilder : TextureBuilder
 
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
+        data.RoomEdits.AddRange(FixCatwalks(level));
 
         FixPassport(level, data);
         FixPushButton(data);
@@ -34,6 +35,7 @@ public class TR2DivingTextureBuilder : TextureBuilder
             Reface(level, 28, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1965, 1),
             Reface(level, 30, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1916, 4),
             Reface(level, 30, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1916, 7),
+            Reface(level, 52, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1985, 4),
             Reface(level, 77, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1946, 39),
         };
     }

--- a/src/Types/TR2/Textures/TR2FurnaceTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2FurnaceTextureBuilder.cs
@@ -17,6 +17,7 @@ public class TR2FurnaceTextureBuilder : TextureBuilder
 
         FixWolfTransparency(furnace, data);
 
+        data.RoomEdits.AddRange(CreateVertexShifts(furnace));
         data.RoomEdits.AddRange(CreateShifts(furnace));
         data.RoomEdits.AddRange(CreateFillers(furnace));
         data.RoomEdits.AddRange(CreateRefacings(furnace));
@@ -25,6 +26,25 @@ public class TR2FurnaceTextureBuilder : TextureBuilder
         FixPushButton(data);
 
         return new() { data };
+    }
+
+    private static List<TRRoomVertexMove> CreateVertexShifts(TR2Level level)
+    {
+        return new()
+        {
+            new()
+            {
+                RoomIndex = 117,
+                VertexIndex = level.Rooms[117].Mesh.Rectangles[16].Vertices[2],
+                VertexChange = new() { Y = -512 },
+            },
+            new()
+            {
+                RoomIndex = 117,
+                VertexIndex = level.Rooms[117].Mesh.Rectangles[16].Vertices[3],
+                VertexChange = new() { Y = -512 },
+            },
+        };
     }
 
     private static List<TRRoomTextureMove> CreateShifts(TR2Level level)
@@ -71,6 +91,19 @@ public class TR2FurnaceTextureBuilder : TextureBuilder
                     level.Rooms[10].Mesh.Rectangles[32].Vertices[2],
                 }
             },
+            new()
+            {
+                RoomIndex = 117,
+                FaceType = TRMeshFaceType.TexturedTriangle,
+                SourceRoom = 117,
+                SourceIndex = 4,
+                Vertices = new()
+                {
+                    level.Rooms[117].Mesh.Rectangles[16].Vertices[0],
+                    level.Rooms[117].Mesh.Rectangles[16].Vertices[3],
+                    level.Rooms[117].Mesh.Rectangles[12].Vertices[2],
+                }
+            },
         };
     }
 
@@ -78,12 +111,17 @@ public class TR2FurnaceTextureBuilder : TextureBuilder
     {
         return new()
         {
+            Reface(level, 97, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1412, 32),
+            Reface(level, 97, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1713, 38),
+            Reface(level, 97, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1412, 134),
             Reface(level, 99, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1420, 17),
             Reface(level, 99, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1420, 20),
             Reface(level, 99, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1412, 130),
             Reface(level, 101, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1412, 11),
+            Reface(level, 105, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1420, 8),
             Reface(level, 108, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1420, 7),
             Reface(level, 120, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1420, 0),
+            Reface(level, 124, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1750, 5),
         };
     }
 }

--- a/src/Types/TR2/Textures/TR2GymTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2GymTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRImageControl;
+﻿using System.Drawing;
+using TRImageControl;
 using TRImageControl.Packing;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
@@ -17,7 +18,7 @@ public class TR2GymTextureBuilder : TextureBuilder
         InjectionData data = CreateBaseData();
 
         TR2Level gym = _control2.Read($"Resources/{TR2LevelNames.ASSAULT}");
-        FixLaraTransparency(gym, data);
+        FixTransparentTextures(gym, data);
 
         data.RoomEdits.AddRange(CreateVertexShifts(gym));
         data.RoomEdits.AddRange(CreateShifts(gym));
@@ -186,5 +187,12 @@ public class TR2GymTextureBuilder : TextureBuilder
             {
                 f.Texture = (ushort)level.ObjectTextures.IndexOf(originalInfos[f.Texture]);
             });
+    }
+
+    private static void FixTransparentTextures(TR2Level level, InjectionData data)
+    {
+        FixLaraTransparency(level, data);
+        FixTransparentPixels(level, data,
+            level.Rooms[55].Mesh.Rectangles[70], Color.FromArgb(148, 32, 0));
     }
 }

--- a/src/Types/TR2/Textures/TR2HSHTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2HSHTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using System.Drawing;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -14,7 +15,7 @@ public class TR2HSHTextureBuilder : TextureBuilder
         InjectionData data = CreateBaseData();
 
         TR2Level house = _control2.Read($"Resources/{TR2LevelNames.HOME}");
-        FixLaraTransparency(house, data);
+        FixTransparentTextures(house, data);
 
         data.RoomEdits.AddRange(CreateVertexShifts(house));
         data.RoomEdits.AddRange(CreateShifts(house));
@@ -209,6 +210,13 @@ public class TR2HSHTextureBuilder : TextureBuilder
             Rotate(34, TRMeshFaceType.TexturedQuad, 38, 3),
             Rotate(54, TRMeshFaceType.TexturedQuad, 15, 3),
         };
+    }
+
+    private static void FixTransparentTextures(TR2Level level, InjectionData data)
+    {
+        FixLaraTransparency(level, data);
+        FixTransparentPixels(level, data,
+            level.Rooms[52].Mesh.Rectangles[70], Color.FromArgb(148, 32, 0));
     }
 
     private InjectionData CreateBaseData()

--- a/src/Types/TR2/Textures/TR2IcePalaceTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2IcePalaceTextureBuilder.cs
@@ -16,9 +16,24 @@ public class TR2IcePalaceTextureBuilder : TextureBuilder
         CreateDefaultTests(data, TR2LevelNames.CHICKEN);
 
         data.RoomEdits.AddRange(CreateVertexShifts(level));
+        data.RoomEdits.AddRange(CreateShifts(level));
         data.RoomEdits.AddRange(CreateFillers(level));
         data.RoomEdits.AddRange(CreateRefacings(level));
         data.RoomEdits.AddRange(CreateRotations());
+
+        data.VisPortalEdits.Add(new()
+        {
+            BaseRoom = 121,
+            LinkRoom = 50,
+            PortalIndex = 3,
+            VertexChanges = new()
+            {
+                new(),
+                new() { Y = 768, },
+                new() { Y = 768, },
+                new(),
+            }
+        });
 
         FixPassport(level, data);
 
@@ -40,6 +55,60 @@ public class TR2IcePalaceTextureBuilder : TextureBuilder
                 RoomIndex = 31,
                 VertexIndex = level.Rooms[31].Mesh.Rectangles[133].Vertices[3],
                 VertexChange = new() { Y = 256 },
+            },
+            new()
+            {
+                RoomIndex = 92,
+                VertexIndex = level.Rooms[92].Mesh.Rectangles[135].Vertices[1],
+                VertexChange = new() { Y = 256 },
+                ShadeChange = -1638,
+            },
+            new()
+            {
+                RoomIndex = 92,
+                VertexIndex = level.Rooms[92].Mesh.Rectangles[130].Vertices[0],
+                VertexChange = new() { Y = 256 },
+                ShadeChange = -1638,
+            },
+            new()
+            {
+                RoomIndex = 121,
+                VertexIndex = level.Rooms[121].Mesh.Rectangles[135].Vertices[1],
+                VertexChange = new() { Y = 256 },
+                ShadeChange = -1638,
+            },
+            new()
+            {
+                RoomIndex = 121,
+                VertexIndex = level.Rooms[121].Mesh.Rectangles[130].Vertices[0],
+                VertexChange = new() { Y = 256 },
+                ShadeChange = -1638,
+            },
+        };
+    }
+
+    private static List<TRRoomTextureMove> CreateShifts(TR2Level level)
+    {
+        return new()
+        {
+            new()
+            {
+                RoomIndex = 121,
+                FaceType = TRMeshFaceType.TexturedQuad,
+                TargetIndex = 138,
+                VertexRemap = new()
+                {
+                    new()
+                    {
+                        Index = 0,
+                        NewVertexIndex = level.Rooms[121].Mesh.Rectangles[135].Vertices[1],
+                    },
+                    new()
+                    {
+                        Index = 1,
+                        NewVertexIndex = level.Rooms[121].Mesh.Rectangles[130].Vertices[0],
+                    }
+                }
             },
         };
     }
@@ -73,6 +142,10 @@ public class TR2IcePalaceTextureBuilder : TextureBuilder
             Reface(level, 31, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1356, 144),
             Reface(level, 31, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1356, 147),
             Reface(level, 31, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1356, 150),
+            Reface(level, 52, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedQuad, 1376, 6),
+            Reface(level, 66, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1346, 55),
+            Reface(level, 124, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1488, 4),
+            Reface(level, 124, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedQuad, 1376, 6),
         };
     }
 
@@ -80,7 +153,12 @@ public class TR2IcePalaceTextureBuilder : TextureBuilder
     {
         return new()
         {
+            Rotate(49, TRMeshFaceType.TexturedTriangle, 0, 2),
             Rotate(52, TRMeshFaceType.TexturedTriangle, 3, 2),
+            Rotate(52, TRMeshFaceType.TexturedTriangle, 6, 2),
+            Rotate(120, TRMeshFaceType.TexturedTriangle, 0, 2),
+            Rotate(124, TRMeshFaceType.TexturedTriangle, 3, 2),
+            Rotate(124, TRMeshFaceType.TexturedTriangle, 6, 2),
         };
     }
 }

--- a/src/Types/TR2/Textures/TR2LivingTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2LivingTextureBuilder.cs
@@ -15,12 +15,32 @@ public class TR2LivingTextureBuilder : TextureBuilder
         InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.TextureFix, ID);
         CreateDefaultTests(data, TR2LevelNames.LQ);
 
+        data.RoomEdits.AddRange(CreateVertexShifts(level));
         data.RoomEdits.AddRange(CreateRefacings(level));
 
         FixPassport(level, data);
         FixPushButton(data);
 
         return new() { data };
+    }
+
+    private static List<TRRoomVertexMove> CreateVertexShifts(TR2Level level)
+    {
+        return new()
+        {
+            new()
+            {
+                RoomIndex = 70,
+                VertexIndex = level.Rooms[70].Mesh.Rectangles[108].Vertices[0],
+                VertexChange = new() { Y = 256 },
+            },
+            new()
+            {
+                RoomIndex = 70,
+                VertexIndex = level.Rooms[70].Mesh.Rectangles[108].Vertices[1],
+                VertexChange = new() { Y = 256 },
+            },
+        };
     }
 
     private static IEnumerable<TRRoomTextureReface> CreateRefacings(TR2Level level)

--- a/src/Types/TR2/Textures/TR2RigTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2RigTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using System.Drawing;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -19,7 +20,7 @@ public class TR2RigTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateFillers(level));
         data.RoomEdits.AddRange(CreateRefacings(level));
         FixThinWall(level, data);
-
+        FixTransparentTextures(level, data);
         FixPassport(level, data);
         FixPushButton(data);
         FixWheelDoor(data, TR2LevelNames.RIG);
@@ -202,5 +203,11 @@ public class TR2RigTextureBuilder : TextureBuilder
                 }
             }
         });
+    }
+
+    private static void FixTransparentTextures(TR2Level level, InjectionData data)
+    {
+        FixTransparentPixels(level, data,
+            level.Rooms[96].Mesh.Rectangles[27], Color.FromArgb(246, 238, 213));
     }
 }

--- a/src/Types/TR2/Textures/TR2RigTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2RigTextureBuilder.cs
@@ -6,7 +6,7 @@ using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR2.Textures;
 
-public class TR2RigTextureBuilder : TextureBuilder
+public partial class TR2RigTextureBuilder : TextureBuilder
 {
     public override string ID => "rig_textures";
 
@@ -19,6 +19,8 @@ public class TR2RigTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateShifts(level));
         data.RoomEdits.AddRange(CreateFillers(level));
         data.RoomEdits.AddRange(CreateRefacings(level));
+        data.RoomEdits.AddRange(CreateRotations());
+        data.RoomEdits.AddRange(FixCatwalks(level));
         FixThinWall(level, data);
         FixTransparentTextures(level, data);
         FixPassport(level, data);
@@ -114,8 +116,17 @@ public class TR2RigTextureBuilder : TextureBuilder
         return new()
         {
             Reface(level, 11, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1622, 137),
+            Reface(level, 33, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1736, 0),
             Reface(level, 35, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1702, 42),
             Reface(level, 81, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1702, 33),
+        };
+    }
+
+    private static List<TRRoomTextureRotate> CreateRotations()
+    {
+        return new()
+        {
+            Rotate(33, TRMeshFaceType.TexturedTriangle, 0, 2),
         };
     }
 

--- a/src/Types/TR2/Textures/TR2TibetTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2TibetTextureBuilder.cs
@@ -67,6 +67,9 @@ public class TR2TibetTextureBuilder : TextureBuilder
             Reface(level, 12, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1292, 78),
             Reface(level, 28, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1361, 1),
             Reface(level, 40, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1288, 157),
+            Reface(level, 71, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1411, 5),
+            Reface(level, 72, TRMeshFaceType.TexturedTriangle, TRMeshFaceType.TexturedTriangle, 1321, 8),
+            Reface(level, 72, TRMeshFaceType.TexturedQuad, TRMeshFaceType.TexturedQuad, 1411, 192),
         };
     }
 
@@ -86,6 +89,12 @@ public class TR2TibetTextureBuilder : TextureBuilder
             Rotate(15, TRMeshFaceType.TexturedTriangle, 3, 2),
             Rotate(15, TRMeshFaceType.TexturedTriangle, 4, 2),
             Rotate(28, TRMeshFaceType.TexturedTriangle, 1, 1),
+            Rotate(71, TRMeshFaceType.TexturedQuad, 5, 2),
+            Rotate(72, TRMeshFaceType.TexturedQuad, 114, 2),
+            Rotate(72, TRMeshFaceType.TexturedQuad, 142, 2),
+            Rotate(72, TRMeshFaceType.TexturedQuad, 169, 2),
+            Rotate(72, TRMeshFaceType.TexturedQuad, 192, 1),
+            Rotate(72, TRMeshFaceType.TexturedQuad, 212, 2),
         };
     }
 }

--- a/src/Types/TR2/Textures/TR2VeniceTextureBuilder.cs
+++ b/src/Types/TR2/Textures/TR2VeniceTextureBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Helpers;
+﻿using System.Drawing;
+using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
@@ -20,7 +21,7 @@ public class TR2VeniceTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateRotations());
         data.MeshEdits.Add(
             FixStaticMeshPosition(venice.StaticMeshes, TR2Type.Architecture4, new() { Z = 27 }));
-
+        FixTransparentTextures(venice, data);
         FixPassport(venice, data);
         FixPushButton(data);
 
@@ -96,5 +97,11 @@ public class TR2VeniceTextureBuilder : TextureBuilder
             Rotate(36, TRMeshFaceType.TexturedQuad, 22, 2),
             Rotate(36, TRMeshFaceType.TexturedQuad, 88, 2),
         };
+    }
+
+    private static void FixTransparentTextures(TR2Level level, InjectionData data)
+    {
+        FixTransparentPixels(level, data,
+            level.Rooms[0].Mesh.Rectangles[56], Color.FromArgb(139, 131, 41));
     }
 }

--- a/src/Types/TextureBuilder.cs
+++ b/src/Types/TextureBuilder.cs
@@ -272,7 +272,15 @@ public abstract class TextureBuilder : InjectionBuilder
         GenerateImages8(baseLevel, baseLevel.Palette.Select(c => c.ToTR1Color()).ToList());
     }
 
-    private static TRImage GetImage(ushort texture, TR2Level level)
+    protected static TRImage GetImage(ushort texture, TR1Level level)
+    {
+        var texInfo = level.ObjectTextures[texture];
+        var page = level.Images8[texInfo.Atlas];
+        return new TRImage(page.Pixels, level.Palette)
+            .Export(texInfo.Bounds);
+    }
+
+    protected static TRImage GetImage(ushort texture, TR2Level level)
     {
         var texInfo = level.ObjectTextures[texture];
         var page = level.Images16[texInfo.Atlas];
@@ -280,7 +288,16 @@ public abstract class TextureBuilder : InjectionBuilder
             .Export(texInfo.Bounds);
     }
 
-    private static void ImportImage(ushort texture, TRImage img, TR2Level level)
+    protected static void ImportImage(ushort texture, TRImage img, TR1Level level)
+    {
+        var texInfo = level.ObjectTextures[texture];
+        var page = level.Images8[texInfo.Atlas];
+        var image = new TRImage(page.Pixels, level.Palette);
+        image.Import(img, texInfo.Position);
+        level.Images8[texInfo.Atlas].Pixels = image.ToRGB(level.Palette);
+    }
+
+    protected static void ImportImage(ushort texture, TRImage img, TR2Level level)
     {
         var texInfo = level.ObjectTextures[texture];
         var page = level.Images16[texInfo.Atlas];

--- a/src/Types/TextureBuilder.cs
+++ b/src/Types/TextureBuilder.cs
@@ -112,6 +112,17 @@ public abstract class TextureBuilder : InjectionBuilder
         };
     }
 
+    protected static TRRoomTextureMove CreateQuadShift(short roomIdx, short targetIdx, List<TRRoomVertexRemap> remap)
+    {
+        return new()
+        {
+            RoomIndex = roomIdx,
+            FaceType = TRMeshFaceType.TexturedQuad,
+            TargetIndex = targetIdx,
+            VertexRemap = remap,
+        };
+    }
+
     protected static TRMeshEdit FixStaticMeshPosition<T>(TRDictionary<T, TRStaticMesh> meshes, T id, TRVertex change)
         where T : Enum
     {

--- a/src/Types/TextureBuilder.cs
+++ b/src/Types/TextureBuilder.cs
@@ -93,6 +93,25 @@ public abstract class TextureBuilder : InjectionBuilder
         };
     }
 
+    protected static TRRoomVertexCreate CreateVertex(short roomIdx, TR1Room room, TR1RoomVertex vertex, short lighting = -1)
+    {
+        room.Mesh.Vertices.Add(vertex.Clone() as TR1RoomVertex);
+        return new()
+        {
+            RoomIndex = roomIdx,
+            Vertex = new()
+            {
+                Lighting = lighting == -1 ? vertex.Lighting : lighting,
+                Vertex = new()
+                {
+                    X = vertex.Vertex.X,
+                    Y = (short)(vertex.Vertex.Y + 256),
+                    Z = vertex.Vertex.Z,
+                },
+            },
+        };
+    }
+
     protected static TRRoomVertexCreate CreateVertex(short roomIdx, TR2Room room, TR2RoomVertex vertex, short lighting = -1)
     {
         room.Mesh.Vertices.Add(vertex.Clone() as TR2RoomVertex);

--- a/src/Types/TextureBuilder.cs
+++ b/src/Types/TextureBuilder.cs
@@ -93,7 +93,7 @@ public abstract class TextureBuilder : InjectionBuilder
         };
     }
 
-    protected static TRRoomVertexCreate CreateVertex(short roomIdx, TR2Room room, TR2RoomVertex vertex)
+    protected static TRRoomVertexCreate CreateVertex(short roomIdx, TR2Room room, TR2RoomVertex vertex, short lighting = -1)
     {
         room.Mesh.Vertices.Add(vertex.Clone() as TR2RoomVertex);
         return new()
@@ -101,7 +101,7 @@ public abstract class TextureBuilder : InjectionBuilder
             RoomIndex = roomIdx,
             Vertex = new()
             {
-                Lighting = vertex.Lighting,
+                Lighting = lighting == -1 ? vertex.Lighting : lighting,
                 Vertex = new()
                 {
                     X = vertex.Vertex.X,
@@ -109,6 +109,22 @@ public abstract class TextureBuilder : InjectionBuilder
                     Z = vertex.Vertex.Z,
                 },
             },
+        };
+    }
+
+    protected static TRRoomVertxFlagChange SetLastVertexFlags(short roomIdx, TR2Room room)
+    {
+        return SetVertexFlags(roomIdx, room, (ushort)(room.Mesh.Vertices.Count - 1));
+    }
+
+    protected static TRRoomVertxFlagChange SetVertexFlags(short roomIdx, TR2Room room, ushort vtxIdx)
+    {
+        var vertex = room.Mesh.Vertices[vtxIdx];
+        return new()
+        {
+            RoomIndex = roomIdx,
+            VertexIndex = vtxIdx,
+            Flags = vertex.Attributes,
         };
     }
 

--- a/src/Types/TextureBuilder.cs
+++ b/src/Types/TextureBuilder.cs
@@ -80,6 +80,38 @@ public abstract class TextureBuilder : InjectionBuilder
         return null;
     }
 
+    public static TRRoomTextureCreate CreateFace(short roomIdx, short sourceRoom, ushort sourceIndex,
+        TRMeshFaceType faceType, ushort[] vertices)
+    {
+        return new()
+        {
+            RoomIndex = roomIdx,
+            FaceType = faceType,
+            SourceRoom = sourceRoom,
+            SourceIndex = (short)sourceIndex,
+            Vertices = new(vertices),
+        };
+    }
+
+    protected static TRRoomVertexCreate CreateVertex(short roomIdx, TR2Room room, TR2RoomVertex vertex)
+    {
+        room.Mesh.Vertices.Add(vertex.Clone() as TR2RoomVertex);
+        return new()
+        {
+            RoomIndex = roomIdx,
+            Vertex = new()
+            {
+                Lighting = vertex.Lighting,
+                Vertex = new()
+                {
+                    X = vertex.Vertex.X,
+                    Y = (short)(vertex.Vertex.Y + 256),
+                    Z = vertex.Vertex.Z,
+                },
+            },
+        };
+    }
+
     protected static TRMeshEdit FixStaticMeshPosition<T>(TRDictionary<T, TRStaticMesh> meshes, T id, TRVertex change)
         where T : Enum
     {

--- a/src/Util/TRModelExtensions.cs
+++ b/src/Util/TRModelExtensions.cs
@@ -73,6 +73,19 @@ public static class TRModelExtensions
         mesh.CollRadius = (int)Math.Ceiling((inner + outer) / 2d);
     }
 
+    public static void Rotate(this TRFace face, int rots)
+    {
+        for (int i = 0; i < rots; i++)
+        {
+            ushort first = face.Vertices[0];
+            for (int j = 0; j < face.Vertices.Count - 1; j++)
+            {
+                face.Vertices[j] = face.Vertices[j + 1];
+            }
+            face.Vertices[^1] = first;
+        }
+    }
+
     public static void Serialize(this LM.TRModel model, TRLevelWriter writer, TRGameVersion version)
     {
         writer.Write((int)model.ID, TRObjectType.Game, version);


### PR DESCRIPTION
Fixes dozens of missing and incorrect textures throughout TR1 and TR2. This could be more cleverly data-driven but I've opted just to keep the complicated fixes like the catwalks in separate modules. There is at least some sharing between them e.g. between diving area and its cutscene, and the flipmap at the start of Atlantis.