### PR TITLE
Fix Tinnos mask cameras

### DIFF
--- a/src/Types/TR3/FD/TR3TinnosFDBuilder.cs
+++ b/src/Types/TR3/FD/TR3TinnosFDBuilder.cs
@@ -1,0 +1,54 @@
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Actions;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR3.FD;
+
+public class TR3TinnosFDBuilder : FDBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        var data = InjectionData.Create(TRGameVersion.TR3, InjectionType.General, "tinnos_fd");
+        CreateDefaultTests(data, $"TR3/{TR3LevelNames.TINNOS}");
+        data.FloorEdits.AddRange(FixMaskCameras());
+
+        return [data];
+    }
+
+    private static IEnumerable<TRFloorDataEdit> FixMaskCameras()
+    {
+        var level = _control3.Read($"Resources/TR3/{TR3LevelNames.TINNOS}");
+        var room = level.Rooms[67];
+
+        for (ushort x = 2; x <= 4; x++)
+        {
+            for (ushort z = 2; z <= 4; z++)
+            {
+                if (x == 3 && z == 3)
+                {
+                    continue;
+                }
+
+                var sector = room.GetSector(x, z, TRUnit.Sector);
+                if (sector.FDIndex == 0)
+                {
+                    continue;
+                }
+
+                var trigger = level.FloorData[sector.FDIndex].OfType<FDTriggerEntry>()
+                    .Where(t => t.Actions.Any(a => a.Action == FDTrigAction.Camera))
+                    .FirstOrDefault();
+                if (trigger == null)
+                {
+                    continue;
+                }
+
+                trigger = trigger.Clone() as FDTriggerEntry;
+                trigger.TrigType = FDTrigType.Dummy;
+                trigger.Actions.RemoveAll(a => a.Action != FDTrigAction.Camera);
+                yield return MakeTrigger(level, room.AlternateRoom, x, z, trigger);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes the camera being cut-off early if Lara uses the Uli key before placing the masks in Tinnos. A dummy camera trigger is placed in the flip room under each puzzle slot.