### PR TITLE
Add mine cart FD edit support

### DIFF
--- a/src/Actions/TRFloorDataEdit.cs
+++ b/src/Actions/TRFloorDataEdit.cs
@@ -40,6 +40,15 @@ public enum FDFixType
     ClimbInsert,
     TrigDelete,
     Triangulation,
+    MineCart,
+}
+
+public enum MineCartType
+{
+    None,
+    Left,
+    Right,
+    Stop,
 }
 
 public abstract class FDFix
@@ -277,6 +286,17 @@ public class FDTrigDelete : FDFix
 
     protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
     {
+    }
+}
+
+public class FDMineCartEdit : FDFix
+{
+    public override FDFixType FixType => FDFixType.MineCart;
+    public MineCartType Type { get; set; }
+
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
+    {
+        writer.Write((int)Type);
     }
 }
 


### PR DESCRIPTION
This allows the mine cart type to be edited per sector.