### PR TITLE
Harden texture injection tests

### DIFF
--- a/src/Applicability/ApplicabilityType.cs
+++ b/src/Applicability/ApplicabilityType.cs
@@ -5,4 +5,5 @@ public enum ApplicabilityType
     ItemMeta = 0,
     RoomCount = 1,
     RoomMeta = 2,
+    TextureSample = 3,
 }

--- a/src/Applicability/TextureTest.cs
+++ b/src/Applicability/TextureTest.cs
@@ -1,0 +1,57 @@
+﻿using TRLevelControl;
+using TRLevelControl.Model;
+
+namespace TRXInjectionTool.Applicability;
+
+public class TextureTest(int textureIndex, TRObjectTexture texture)
+    : ApplicabilityTest
+{
+    public override ApplicabilityType Type => ApplicabilityType.TextureSample;
+    public int TextureIndex { get; set; } = textureIndex;
+    public TRObjectTexture Texture { get; set; } = texture;
+
+    protected override void SerializeImpl(TRLevelWriter writer, TRGameVersion version)
+    {
+        writer.Write(TextureIndex);
+        writer.Write((ushort)Texture.BlendingMode);
+        writer.Write(Texture.Atlas);
+
+        var info = Texture.Clone();
+        if (version == TRGameVersion.TR3)
+        {
+            DecodeTR3ObjectTextureUVs(info);
+        }
+        writer.Write(info.Vertices);
+    }
+
+    public static void DecodeTR3ObjectTextureUVs(TRObjectTexture texture)
+    {
+        short[] uv = [.. texture.Vertices.SelectMany(v => new[] { (short)v.U, (short)v.V })];
+        byte flags = 0;
+
+        for (int i = 0; i < uv.Length; i++)
+        {
+            if ((uv[i] & 0x80) != 0)
+            {
+                uv[i] |= 0x00FF;
+                flags |= (byte)(1 << i);
+            }
+            else
+            {
+                uv[i] &= unchecked((short)0xFF00);
+            }
+        }
+
+        for (int i = 0; i < uv.Length; i++)
+        {
+            uv[i] += (flags & 1) != 0 ? (short)-256 : (short)256;
+            flags >>= 1;
+        }
+
+        for (int i = 0; i < texture.Vertices.Count; i++)
+        {
+            texture.Vertices[i].U = (ushort)uv[i * 2];
+            texture.Vertices[i].V = (ushort)uv[i * 2 + 1];
+        }
+    }
+}

--- a/src/Types/TR1/Textures/TR1ColosseumTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1ColosseumTextureBuilder.cs
@@ -1,7 +1,9 @@
-﻿using TRImageControl;
+﻿using System.Diagnostics;
+using TRImageControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
+using TRXInjectionTool.Applicability;
 using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR1.Textures;
@@ -20,7 +22,7 @@ public class TR1ColosseumTextureBuilder : TextureBuilder
         data.RoomEdits.AddRange(CreateVertexShifts(colosseum));
         data.RoomEdits.AddRange(CreateRotations());
 
-        FixRoofTextures(data);
+        FixRoofTextures(colosseum, data);
         FixPassport(colosseum, data);
 
         return new() { data };
@@ -133,7 +135,7 @@ public class TR1ColosseumTextureBuilder : TextureBuilder
         };
     }
 
-    private static void FixRoofTextures(InjectionData data)
+    private static void FixRoofTextures(TR1Level level, InjectionData data)
     {
         // Replace the Midas textures used on the roof of Colosseum with
         // those from the beta.
@@ -147,5 +149,13 @@ public class TR1ColosseumTextureBuilder : TextureBuilder
             Height = 64,
             Data = betaRoof.ToRGBA(),
         });
+
+        var texId = level.ObjectTextures.FindIndex(t => t.Atlas == 3
+            && t.Position.X == 128
+            && t.Position.Y == 0
+            && t.Size.Width == 64
+            && t.Size.Height == 64);
+        Debug.Assert(texId != -1);
+        data.ApplicabilityTests.Add(new TextureTest(texId, level.ObjectTextures[texId]));
     }
 }

--- a/src/Types/TR1/Textures/TR1MidasTextureBuilder.cs
+++ b/src/Types/TR1/Textures/TR1MidasTextureBuilder.cs
@@ -3,6 +3,7 @@ using TRImageControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
+using TRXInjectionTool.Applicability;
 using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR1.Textures;
@@ -218,6 +219,7 @@ public class TR1MidasTextureBuilder : TextureBuilder
             });
         }
 
+        bool testAdded = false;
         foreach (var id in new[] { 784, 786, 788, 798, 818, 832 })
         {
             var info = level.ObjectTextures[id];
@@ -226,6 +228,12 @@ public class TR1MidasTextureBuilder : TextureBuilder
             if (!img.Pixels.Any(p => p == 0))
             {
                 continue;
+            }
+
+            if (!testAdded)
+            {
+                data.ApplicabilityTests.Add(new TextureTest(id, info));
+                testAdded = true;
             }
 
             img.Write((c, x, y) =>

--- a/src/Types/TR3/Misc/TR3UnderseaAnimatingExtBuilder.cs
+++ b/src/Types/TR3/Misc/TR3UnderseaAnimatingExtBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using TRLevelControl.Helpers;
-using TRXInjectionTool.Actions;
 using TRLevelControl.Model;
 using TRXInjectionTool.Control;
 

--- a/src/Types/TR3/Textures/TR3Area51TextureBuilder.cs
+++ b/src/Types/TR3/Textures/TR3Area51TextureBuilder.cs
@@ -15,7 +15,7 @@ public class TR3Area51TextureBuilder : TextureBuilder
 
         FixSlidingDoor(data);
         FixPushButton(data, TR3LevelNames.AREA51);
-        data.TextureOverwrites.Add(TR3HSCTextureBuilder.FixGrating(level, 2023));
+        TR3HSCTextureBuilder.FixGrating(level, 2023, data);
 
         return [data];
     }

--- a/src/Types/TR3/Textures/TR3HSCTextureBuilder.cs
+++ b/src/Types/TR3/Textures/TR3HSCTextureBuilder.cs
@@ -3,6 +3,7 @@ using TRImageControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
+using TRXInjectionTool.Applicability;
 using TRXInjectionTool.Control;
 
 namespace TRXInjectionTool.Types.TR3.Textures;
@@ -16,7 +17,7 @@ public class TR3HSCTextureBuilder : TextureBuilder
         CreateDefaultTests(data, $"TR3/{TR3LevelNames.HSC}");
 
         data.RoomEdits.AddRange(CreateRefacings(level));
-        data.TextureOverwrites.Add(FixGrating(level, 1859));
+        FixGrating(level, 1859, data);
 
         FixPushButton(data, TR3LevelNames.HSC);
 
@@ -62,7 +63,7 @@ public class TR3HSCTextureBuilder : TextureBuilder
         }
     }
 
-    public static TRTextureOverwrite FixGrating(TR3Level level, int textureId)
+    public static void FixGrating(TR3Level level, int textureId, InjectionData data)
     {
         var texInfo = level.ObjectTextures[textureId];
         var tile = new TRImage(level.Images16[texInfo.Atlas].Pixels);
@@ -90,7 +91,7 @@ public class TR3HSCTextureBuilder : TextureBuilder
             return c;
         });
 
-        return new()
+        data.TextureOverwrites.Add(new()
         {
             Page = texInfo.Atlas,
             X = (byte)texInfo.Bounds.X,
@@ -98,6 +99,8 @@ public class TR3HSCTextureBuilder : TextureBuilder
             Width = (ushort)texInfo.Size.Width,
             Height = (ushort)texInfo.Size.Height,
             Data = img.ToRGBA(),
-        };
+        });
+
+        data.ApplicabilityTests.Add(new TextureTest(textureId, texInfo));
     }
 }

--- a/src/Types/TextureBuilder.cs
+++ b/src/Types/TextureBuilder.cs
@@ -6,6 +6,7 @@ using TRLevelControl;
 using TRLevelControl.Helpers;
 using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
+using TRXInjectionTool.Applicability;
 using TRXInjectionTool.Control;
 using TRXInjectionTool.Util;
 
@@ -299,6 +300,7 @@ public abstract class TextureBuilder : InjectionBuilder
             Height = (ushort)texInfo.Size.Height,
             Data = img.ToRGBA(),
         });
+        data.ApplicabilityTests.Add(new TextureTest(face.Texture, texInfo));
     }
 
     protected static TR1Level CreateAtlantisContinuityLevel(TR1Type startSceneryIdx)
@@ -741,6 +743,9 @@ public abstract class TextureBuilder : InjectionBuilder
                     Data = img.ToRGBA(),
                 });
             }
+
+            var first = texInfos.First();
+            data.ApplicabilityTests.Add(new TextureTest(level.ObjectTextures.IndexOf(first), first));
         }
         else if (level is TR2Level)
         {


### PR DESCRIPTION
This improves applicability tests for texture page overwrite injections by allowing for particular tex infos from the injection source levels to be compared with the runtime levels.