### PR TITLE
crystals: add per-mode crystal meshes 

### DIFF
--- a/src/Types/TR1/Crystals/TR1CrystalBuilder.cs
+++ b/src/Types/TR1/Crystals/TR1CrystalBuilder.cs
@@ -6,6 +6,8 @@ namespace TRXInjectionTool.Types.TR1.Crystals;
 
 public class TR1CrystalBuilder : InjectionBuilder
 {
+    private const short _collectSFXId = 277;
+
     public override List<InjectionData> Build()
         => [.. CreatePlacements(), CreateModel()];
 
@@ -23,5 +25,5 @@ public class TR1CrystalBuilder : InjectionBuilder
     }
 
     private static InjectionData CreateModel()
-        => CrystalUtils.MakeCrystal(TRGameVersion.TR1);
+        => CrystalUtils.MakeCrystal(TRGameVersion.TR1, _collectSFXId);
 }

--- a/src/Types/TR2/Crystals/TR2CrystalBuilder.cs
+++ b/src/Types/TR2/Crystals/TR2CrystalBuilder.cs
@@ -6,6 +6,8 @@ namespace TRXInjectionTool.Types.TR2.Crystals;
 
 public class TR2CrystalBuilder : InjectionBuilder
 {
+    private const short _collectSFXId = 379;
+
     public override List<InjectionData> Build()
         => [.. CreatePlacements(), CreateModel()];
 
@@ -23,5 +25,5 @@ public class TR2CrystalBuilder : InjectionBuilder
     }
 
     private static InjectionData CreateModel()
-        => CrystalUtils.MakeCrystal(TRGameVersion.TR2);
+        => CrystalUtils.MakeCrystal(TRGameVersion.TR2, _collectSFXId);
 }

--- a/src/Types/TR3/Crystals/TR3CrystalBuilder.cs
+++ b/src/Types/TR3/Crystals/TR3CrystalBuilder.cs
@@ -1,0 +1,10 @@
+using TRXInjectionTool.Control;
+using TRXInjectionTool.Util;
+
+namespace TRXInjectionTool.Types.TR3.Crystals;
+
+public class TR3CrystalBuilder : InjectionBuilder
+{
+    public override List<InjectionData> Build()
+        => [CrystalUtils.MakeTR3Crystal()];
+}

--- a/src/Util/CrystalUtils.cs
+++ b/src/Util/CrystalUtils.cs
@@ -12,6 +12,7 @@ public static class CrystalUtils
 {
     private static readonly Color _blue = Color.FromArgb(188, 220, 220);
     private static readonly Color _purple = Color.FromArgb(64, 64, 252);
+    private static readonly Color _green = Color.FromArgb(64, 252, 64);
 
     public static Dictionary<string, List<TR1Entity>> GetLocations<T>(string path, T type)
     {
@@ -50,7 +51,7 @@ public static class CrystalUtils
         });
     }
 
-    public static InjectionData MakeCrystal(TRGameVersion version)
+    public static InjectionData MakeCrystal(TRGameVersion version, short collectSFXID)
     {
         var caves = new TR1LevelControl().Read($"Resources/{TR1LevelNames.CAVES}");
         var model = caves.Models[TR1Type.SavegameCrystal_P];
@@ -63,13 +64,18 @@ public static class CrystalUtils
             m.TexturedFaces.ToList().ForEach(f => f.Texture = 0);
         });
 
-        model.Meshes.Add(model.Meshes[0].Clone());
-        model.MeshTrees.Add(new());
-        model.Meshes[1].TexturedFaces.ToList().ForEach(f => f.Texture = 1);
-        
-        foreach (var fr in model.Animations[0].Frames)
+        // One mesh per tint, selected at runtime with mesh_bits. Mesh 0 is the
+        // PC crystal, 1 the PS1 tint, 2 the heal crystal.
+        for (var i = 1; i < 3; i++)
         {
-            fr.Rotations.Add(new());
+            model.Meshes.Add(model.Meshes[0].Clone());
+            model.MeshTrees.Add(new());
+            model.Meshes[i].TexturedFaces.ToList().ForEach(f => f.Texture = (ushort)i);
+
+            foreach (var fr in model.Animations[0].Frames)
+            {
+                fr.Rotations.Add(new());
+            }
         }
 
         TRLevelBase level = version switch
@@ -93,11 +99,134 @@ public static class CrystalUtils
         var img = new TRImage(TRConsts.TPageWidth, TRConsts.TPageHeight);
         img.Fill(new(0, 0, 8, 8), _blue);
         img.Fill(new(8, 0, 8, 8), _purple);
+        img.Fill(new(16, 0, 8, 8), _green);
         level.ObjectTextures.Add(new TRObjectTexture(0, 0, 8, 8));
         level.ObjectTextures.Add(new TRObjectTexture(8, 0, 8, 8));
+        level.ObjectTextures.Add(new TRObjectTexture(16, 0, 8, 8));
+
+        var data = InjectionData.Create(level, InjectionType.General, "crystal");
+        data.Images.Add(new() { Pixels = img.ToRGBA() });
+
+        var jungle = new TR3LevelControl().Read($"Resources/TR3/{TR3LevelNames.JUNGLE}");
+        var collectSFX = jungle.SoundEffects[TR3SFX.SaveCrystal];
+        collectSFX.Volume = 128;
+        data.SFX.Add(TRSFXData.Create(collectSFXID, collectSFX));
+
+        return data;
+    }
+
+    // TR3's crystal is green in the level data, so the saving and pickup modes
+    // cannot simply tint the light. Republish its textures alongside blue
+    // copies, and add a second mesh that uses them.
+    public static InjectionData MakeTR3Crystal()
+    {
+        var source = new TR3LevelControl().Read($"Resources/TR3/{TR3LevelNames.JUNGLE}");
+        var model = source.Models[TR3Type.SaveCrystal_P];
+        var mesh = model.Meshes[0];
+
+        var img = new TRImage(TRConsts.TPageWidth, TRConsts.TPageHeight);
+        var greenTextures = new Dictionary<ushort, ushort>();
+        var blueTextures = new Dictionary<ushort, ushort>();
+        var textures = new List<TRObjectTexture>();
+        var packedRects = new Dictionary<Rectangle, Point>();
+        var packX = 0;
+
+        foreach (var texIndex in mesh.TexturedFaces.Select(f => f.Texture).Distinct())
+        {
+            var texture = source.ObjectTextures[texIndex];
+            var bounds = GetBounds(texture);
+            if (!packedRects.TryGetValue(bounds, out var origin))
+            {
+                origin = new(packX, 0);
+                packedRects[bounds] = origin;
+                packX += bounds.Width;
+
+                var segment = new TRImage(source.Images16[texture.Atlas].Pixels).Export(bounds);
+                img.Import(segment, origin, false);
+                img.Import(segment, origin with { Y = bounds.Height }, false);
+                img.Write(new(origin.X, bounds.Height, bounds.Width, bounds.Height), (c, _, _) => HueRotate(c));
+            }
+
+            greenTextures[texIndex] = (ushort)textures.Count;
+            textures.Add(Remap(texture, bounds, origin));
+            blueTextures[texIndex] = (ushort)textures.Count;
+            textures.Add(Remap(texture, bounds, origin with { Y = bounds.Height }));
+        }
+
+        // Mesh 0 keeps the original green, mesh 1 is the blue copy.
+        model.Meshes.Add(mesh.Clone());
+        model.MeshTrees.Add(new());
+        foreach (var frame in model.Animations[0].Frames)
+        {
+            frame.Rotations.Add(new());
+        }
+        foreach (var face in mesh.TexturedFaces)
+        {
+            face.Texture = greenTextures[face.Texture];
+        }
+        foreach (var face in model.Meshes[1].TexturedFaces)
+        {
+            face.Texture = blueTextures[face.Texture];
+        }
+
+        var level = new TR3LevelControl().Read($"Resources/TR3/{TR3LevelNames.JUNGLE}");
+        InjectionBuilder.ResetLevel(level);
+        level.Models[TR3Type.SaveCrystal_P] = model;
+        level.ObjectTextures.AddRange(textures);
 
         var data = InjectionData.Create(level, InjectionType.General, "crystal");
         data.Images.Add(new() { Pixels = img.ToRGBA() });
         return data;
+    }
+
+    // Object textures store four vertices; a triangle leaves the last unused.
+    private static IEnumerable<TRObjectTextureVert> RealVertices(TRObjectTexture texture)
+        => texture.Vertices.Where(v => v.X != 0 || v.Y != 0);
+
+    private static Rectangle GetBounds(TRObjectTexture texture)
+    {
+        var xs = RealVertices(texture).Select(v => (int)v.X).ToList();
+        var ys = RealVertices(texture).Select(v => (int)v.Y).ToList();
+        return new(xs.Min(), ys.Min(), xs.Max() - xs.Min() + 1, ys.Max() - ys.Min() + 1);
+    }
+
+    private static TRObjectTexture Remap(TRObjectTexture texture, Rectangle bounds, Point origin)
+    {
+        var copy = texture.Clone();
+        copy.Atlas = 0;
+        foreach (var vertex in RealVertices(copy).ToList())
+        {
+            vertex.X = (byte)(origin.X + vertex.X - bounds.X);
+            vertex.Y = (byte)(origin.Y + vertex.Y - bounds.Y);
+        }
+        return copy;
+    }
+
+    // The crystal sits around 119 degrees of hue; this lands it near 219.
+    private static Color HueRotate(Color color)
+    {
+        var hue = (color.GetHue() + 100) % 360;
+        return FromHSV(hue, color.GetSaturation(), color.GetBrightness(), color.A);
+    }
+
+    private static Color FromHSV(float hue, float saturation, float lightness, int alpha)
+    {
+        var c = (1 - Math.Abs(2 * lightness - 1)) * saturation;
+        var x = c * (1 - Math.Abs(hue / 60 % 2 - 1));
+        var m = lightness - c / 2;
+        var (r, g, b) = hue switch
+        {
+            < 60 => (c, x, 0f),
+            < 120 => (x, c, 0f),
+            < 180 => (0f, c, x),
+            < 240 => (0f, x, c),
+            < 300 => (x, 0f, c),
+            _ => (c, 0f, x),
+        };
+        return Color.FromArgb(
+            alpha,
+            (int)Math.Round((r + m) * 255),
+            (int)Math.Round((g + m) * 255),
+            (int)Math.Round((b + m) * 255));
     }
 }


### PR DESCRIPTION
The TR1 and TR2 crystal model carried one mesh per tint, PC and PS1. Add a third, green, for the healing save crystal mode.

TR3's crystal is green in its own level data rather than lit that way, so add a builder that republishes its textures alongside hue-rotated blue copies, and a second mesh that uses them for the saving and pickup modes.

