### PR TITLE
Fix Wreck collapsible tile triggers

### DIFF
--- a/src/Types/TR2/FD/TR2MusicTrackBuilder.cs
+++ b/src/Types/TR2/FD/TR2MusicTrackBuilder.cs
@@ -1,4 +1,5 @@
-﻿using TRLevelControl.Model;
+﻿using TRLevelControl.Helpers;
+using TRLevelControl.Model;
 using TRXInjectionTool.Actions;
 using TRXInjectionTool.Control;
 
@@ -8,14 +9,24 @@ public class TR2MusicTrackBuilder : InjectionBuilder
 {
     public override string ID => "fix_tr2_music_tracks";
 
+    private static readonly Dictionary<string, List<short>> _exclusions = new()
+    {
+        [TR2LevelNames.DORIA] = [70], // see TR2WreckFDBuilder.FixCollapsibleTileTriggers
+    };
+
     public override List<InjectionData> Build()
     {
         var result = new List<InjectionData>();
         foreach (var (levelName, binName) in _tr2NameMap)
         {
             var level = _control2.Read($"Resources/{levelName}");
-            var edits = FixMusicTriggers(level);
-            if (!edits.Any())
+            var edits = FixMusicTriggers(level).ToList();
+            if (_exclusions.TryGetValue(levelName, out var exclusions))
+            {
+                edits.RemoveAll(e => exclusions.Contains(e.RoomIndex));
+            }
+
+            if (edits.Count == 0)
             {
                 continue;
             }

--- a/src/Types/TR2/FD/TR2WreckFDBuilder.cs
+++ b/src/Types/TR2/FD/TR2WreckFDBuilder.cs
@@ -9,23 +9,59 @@ public class TR2WreckFDBuilder : FDBuilder
 {
     public override List<InjectionData> Build()
     {
-        TR2Level wreck = _control2.Read($"Resources/{TR2LevelNames.DORIA}");
-        InjectionData data = InjectionData.Create(TRGameVersion.TR2, InjectionType.FDFix, "wreck_fd");
+        var level = _control2.Read($"Resources/{TR2LevelNames.DORIA}");
+        var data = InjectionData.Create(TRGameVersion.TR2, InjectionType.FDFix, "wreck_fd");
         CreateDefaultTests(data, TR2LevelNames.DORIA);
 
+        data.FloorEdits.Add(FixDrySharkRoom(level));
+        data.FloorEdits.AddRange(FixCollapsibleTileTriggers(level));
+
+        return [data];
+    }
+
+    private static TRFloorDataEdit FixDrySharkRoom(TR2Level level)
+    {
         // Flood room 98 where the unreachable shark is.
-        data.FloorEdits.Add(new()
+        return new()
         {
             RoomIndex = 98,
-            Fixes = new()
+            Fixes = [new FDRoomProperties
             {
-                new FDRoomProperties
-                {
-                    Flags = wreck.Rooms[98].Flags | TRRoomFlag.Water,
-                }
-            }
+                Flags = level.Rooms[98].Flags | TRRoomFlag.Water,
+            }],
+        };
+    }
+
+    private static IEnumerable<TRFloorDataEdit> FixCollapsibleTileTriggers(TR2Level level)
+    {
+        // Room 70 has triggers for collapsible tiles, two of which also hold one-shot music
+        // triggers. Jumping over these means the tiles can never break. Move the music into
+        // a heavy trigger activated by the barrels instead.
+        for (ushort z = 1; z < 3; z++)
+        {
+            var trigger = GetTrigger(level, 70, 2, z).Clone() as FDTriggerEntry;
+            trigger.Actions.RemoveAll(t => t.Action == FDTrigAction.PlaySoundtrack);
+            trigger.OneShot = false;
+            yield return MakeTrigger(level, 70, 2, z, trigger);
+        }
+
+        yield return MakeTrigger(level, 69, 2, 2, new FDTriggerEntry
+        {
+            Mask = 31,
+            TrigType = FDTrigType.HeavyTrigger,
+            OneShot = true,
+            Actions = [new()
+            {
+                Action = FDTrigAction.PlaySoundtrack,
+                Parameter = 32,
+            }],
         });
 
-        return new() { data };
+        {
+            // The second row of triggers is missing one of the barrels as a target.
+            var trigger = GetTrigger(level, 70, 1, 2).Clone() as FDTriggerEntry;
+            trigger.Actions.Add(new() { Parameter = 123 });
+            yield return MakeTrigger(level, 70, 1, 2, trigger);
+        }
     }
 }


### PR DESCRIPTION
This fixes collapsible tiles in Wreck not breaking, and a missing trigger for one of the nearby barrels.