### PR TITLE
Fix doubled lever SFX

### DIFF
--- a/src/Types/TR1/SFX/TR1SwitchSFXBuilder.cs
+++ b/src/Types/TR1/SFX/TR1SwitchSFXBuilder.cs
@@ -1,0 +1,51 @@
+using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR1.SFX;
+
+public class TR1SwitchSFXBuilder : InjectionBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        return new()
+        {
+            FixSwitch(TR1LevelNames.MINES, TR1Type.WallSwitch, "wall_switch_sfx"),
+            FixSwitch(TR1LevelNames.ATLANTIS, TR1Type.UnderwaterSwitch, "uw_switch_sfx"),
+        };
+    }
+
+    private static InjectionData FixSwitch(string levelName, TR1Type type, string binName)
+    {
+        var level = _control1.Read($"Resources/{levelName}");
+        var model = level.Models[type];
+        ResetLevel(level);
+        level.Models[type] = model;
+
+        var anims = new[] { 2, 3 };
+        foreach (int anim in anims)
+        {
+            model.Animations[anim].Commands.RemoveAll(c => c is TRSFXCommand);
+        }
+
+        var data = InjectionData.Create(level, InjectionType.General, binName, true);
+        data.Animations.Clear();
+        data.AnimFrames.Clear();
+        data.AnimChanges.Clear();
+        data.AnimDispatches.Clear();
+        data.Models.Clear();
+
+        foreach (int anim in anims)
+        {
+            data.AnimCmdEdits.Add(new()
+            {
+                TypeID = (int)type,
+                AnimIndex = anim,
+                RawCount = data.AnimCommands.Count / anims.Length,
+                TotalCount = 1,
+            });
+        }
+
+        return data;
+    }
+}

--- a/src/Types/TR2/SFX/TR2SwitchSFXBuilder.cs
+++ b/src/Types/TR2/SFX/TR2SwitchSFXBuilder.cs
@@ -1,0 +1,42 @@
+using TRLevelControl.Helpers;
+using TRLevelControl.Model;
+using TRXInjectionTool.Control;
+
+namespace TRXInjectionTool.Types.TR2.SFX;
+
+public class TR2SwitchSFXBuilder : InjectionBuilder
+{
+    public override List<InjectionData> Build()
+    {
+        var level = _control2.Read($"Resources/{TR2LevelNames.FATHOMS}");
+        var model = level.Models[TR2Type.WallSwitch];
+        ResetLevel(level);
+        level.Models[TR2Type.WallSwitch] = model;
+
+        var anims = new[] { 2, 3 };
+        foreach (int anim in anims)
+        {
+            model.Animations[anim].Commands.RemoveAll(c => c is TRSFXCommand);
+        }
+
+        var data = InjectionData.Create(level, InjectionType.General, "wall_switch_sfx", true);
+        data.Animations.Clear();
+        data.AnimFrames.Clear();
+        data.AnimChanges.Clear();
+        data.AnimDispatches.Clear();
+        data.Models.Clear();
+
+        foreach (int anim in anims)
+        {
+            data.AnimCmdEdits.Add(new()
+            {
+                TypeID = (int)TR2Type.WallSwitch,
+                AnimIndex = anim,
+                RawCount = data.AnimCommands.Count / anims.Length,
+                TotalCount = 1,
+            });
+        }
+
+        return new() { data };
+    }
+}


### PR DESCRIPTION
Some levels carry the lever sound on the switch object's animations as well as on Lara's, so it plays twice. These builders strip the SFX commands from the wall and underwater switch animations, leaving Lara's alone.